### PR TITLE
sunxi: Fix HW address write order

### DIFF
--- a/drivers/net/sunxi_emac.c
+++ b/drivers/net/sunxi_emac.c
@@ -335,8 +335,8 @@ static int _sunxi_write_hwaddr(struct emac_eth_dev *priv, u8 *enetaddr)
 	enetaddr_lo = enetaddr[2] | (enetaddr[1] << 8) | (enetaddr[0] << 16);
 	enetaddr_hi = enetaddr[5] | (enetaddr[4] << 8) | (enetaddr[3] << 16);
 
-	writel(enetaddr_hi, &regs->mac_a1);
-	writel(enetaddr_lo, &regs->mac_a0);
+	writel(enetaddr_lo, &regs->mac_a1);
+	writel(enetaddr_hi, &regs->mac_a0);
 
 	return 0;
 }


### PR DESCRIPTION
Restore the right order of bytes written to the MAC address registers. The order got swapped in commit https://github.com/u-boot/u-boot/commit/ace1520cb5fc2628aa3bbe426d4066d2806d951c.