### PR TITLE
tools/mkimage: Fix DTC run command to handle file names with space

### DIFF
--- a/tools/fit_image.c
+++ b/tools/fit_image.c
@@ -648,11 +648,11 @@ static int fit_handle_file(struct image_tool_params *params)
 		*cmd = '\0';
 	} else if (params->datafile) {
 		/* dtc -I dts -O dtb -p 500 datafile > tmpfile */
-		snprintf(cmd, sizeof(cmd), "%s %s %s > %s",
+		snprintf(cmd, sizeof(cmd), "%s %s \"%s\" > \"%s\"",
 			 MKIMAGE_DTC, params->dtc, params->datafile, tmpfile);
 		debug("Trying to execute \"%s\"\n", cmd);
 	} else {
-		snprintf(cmd, sizeof(cmd), "cp %s %s",
+		snprintf(cmd, sizeof(cmd), "cp \"%s\" \"%s\"",
 			 params->imagefile, tmpfile);
 	}
 	if (*cmd && system(cmd) == -1) {


### PR DESCRIPTION
fit_handle_file function does not quote input and output files while preparing
command to run DTC to convert .its to .itb. This results in a failure if input
or output files contain spaces in their names. Quote input and output files in
DTC command to avoid this failure.

Signed-off-by: Mirza, Taimoor <Taimoor_Mirza@mentor.com>