### PR TITLE
drivers/crypto/fsl: flush cache after performing byte swap on descriptor

### DIFF
--- a/drivers/crypto/fsl/jr.c
+++ b/drivers/crypto/fsl/jr.c
@@ -202,6 +202,12 @@ static int jr_enqueue(uint32_t *desc_addr,
 		sec_out32((uint32_t *)&desc_addr[i], desc_word);
 	}
 
+	unsigned long start = (unsigned long)&desc_addr[0] &
+					~(ARCH_DMA_MINALIGN - 1);
+	unsigned long end = ALIGN((unsigned long)&desc_addr[0] +
+				  (sizeof(desc_addr[0]) * length), ARCH_DMA_MINALIGN);
+	flush_dcache_range(start, end);
+
 	phys_addr_t desc_phys_addr = virt_to_phys(desc_addr);
 
 	jr->info[head].desc_phys_addr = desc_phys_addr;
@@ -209,9 +215,9 @@ static int jr_enqueue(uint32_t *desc_addr,
 	jr->info[head].arg = arg;
 	jr->info[head].op_done = 0;
 
-	unsigned long start = (unsigned long)&jr->info[head] &
+	start = (unsigned long)&jr->info[head] &
 					~(ARCH_DMA_MINALIGN - 1);
-	unsigned long end = ALIGN((unsigned long)&jr->info[head] +
+	end = ALIGN((unsigned long)&jr->info[head] +
 				  sizeof(struct jr_info), ARCH_DMA_MINALIGN);
 	flush_dcache_range(start, end);
 


### PR DESCRIPTION
Existing code fails to flush the cache after performing an optional byte-swap to match the SEC endianess.  This code seems to work if the swap is not necessary, but causes failures on platforms where the swap is needed.  

I used the existing paradigm of start/end calculation followed by a call to flush_dcache_range().