### PR TITLE
[fw_printenv] Delete lock file after file descriptor close

### DIFF
--- a/tools/env/fw_env_main.c
+++ b/tools/env/fw_env_main.c
@@ -274,10 +274,12 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (env_opts.lockname)
-		free(lockname);
-
 	flock(lockfd, LOCK_UN);
 	close(lockfd);
+	unlink(lockname);
+	
+	if (env_opts.lockname)
+	free(lockname);
+	
 	return retval;
 }

--- a/tools/env/fw_env_main.c
+++ b/tools/env/fw_env_main.c
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
 	unlink(lockname);
 	
 	if (env_opts.lockname)
-	free(lockname);
+		free(lockname);
 	
 	return retval;
 }


### PR DESCRIPTION
After fw_printenv call, the lock file still exists, should be removed to allow another call.