### PR TITLE
evb_rk3399: revert CONFIG_SYS_MMC_ENV_DEV to 0

### DIFF
--- a/include/configs/evb_rk3399.h
+++ b/include/configs/evb_rk3399.h
@@ -8,7 +8,7 @@
 
 #include <configs/rk3399_common.h>
 
-#define CONFIG_SYS_MMC_ENV_DEV 1
+#define CONFIG_SYS_MMC_ENV_DEV 0
 
 #define SDRAM_BANK_SIZE			(2UL << 30)
 


### PR DESCRIPTION
This was changed to 1 in commit 0717dde057e, but a few months later,
commit 5f9411af37b swapped the order of eMMC and SD card by assigning
indexed aliases to `&sdhci` and `&sdmmc`.