### PR TITLE
usb echci: limit to 4096 blocks improves

### DIFF
--- a/common/usb_storage.c
+++ b/common/usb_storage.c
@@ -948,8 +948,10 @@ static void usb_stor_set_max_xfer_blk(struct usb_device *udev,
 	 * The U-Boot EHCI driver can handle any transfer length as long as
 	 * there is enough free heap space left, but the SCSI READ(10) and
 	 * WRITE(10) commands are limited to 65535 blocks.
+	 * However, limit to 4096 blocks improves usb-stick compatiblity siginificant.
+	 * Using 65535 leads to "EHCI timed out on TD - token=%#x\n" errors.
 	 */
-	blk = USHRT_MAX;
+	blk = 4096;
 #else
 	blk = 20;
 #endif


### PR DESCRIPTION
Using 65535 blocks with CONFIG_USB_EHCI_HCD gives me 
"EHCI timed out on TD - token=%#x\n" wirh many usb-sticks.
Limit blocks to 4069 increases the usb-stick compatiblity siginificant.