### PR TITLE
Fix Floating GPIO0_D6 - pull up - 4ma

### DIFF
--- a/arch/arm/dts/rk3328-evb.dts
+++ b/arch/arm/dts/rk3328-evb.dts
@@ -25,6 +25,8 @@
 		compatible = "regulator-fixed";
 		regulator-name = "vcc3v3";
 		gpio = <&gpio0 30 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&sdmmc0m1_pwren>;
 		regulator-always-on;
 		regulator-boot-on;
 	};


### PR DESCRIPTION
This fixes a boot failure with SD on ROCK64 Rev3

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
