### PR TITLE
libfdt: Remove superfluous NUL character from overlay symbols

### DIFF
--- a/scripts/dtc/libfdt/fdt_overlay.c
+++ b/scripts/dtc/libfdt/fdt_overlay.c
@@ -757,7 +757,7 @@ static int overlay_symbol_update(void *fdt, void *fdto)
 			   && (memcmp(s, "/__overlay__", len - 1) == 0)) {
 			/* /<fragment-name>/__overlay__ */
 			rel_path = "";
-			rel_path_len = 0;
+			rel_path_len = 1; /* Include NUL character */
 		} else {
 			/* Symbol refers to something that won't end
 			 * up in the target tree */
@@ -794,7 +794,7 @@ static int overlay_symbol_update(void *fdt, void *fdto)
 		}
 
 		ret = fdt_setprop_placeholder(fdt, root_sym, name,
-				len + (len > 1) + rel_path_len + 1, &p);
+				len + (len > 1) + rel_path_len, &p);
 		if (ret < 0)
 			return ret;
 
@@ -820,7 +820,6 @@ static int overlay_symbol_update(void *fdt, void *fdto)
 
 		buf[len] = '/';
 		memcpy(buf + len + 1, rel_path, rel_path_len);
-		buf[len + 1 + rel_path_len] = '\0';
 	}
 
 	return 0;


### PR DESCRIPTION
The symbol path already ends with a NUL character (something which is
actually checked by the code) and this NUL is included in
rel_path_len, so there is no need to add a second one.

This change fixes incorrect display in "fdt list /__symbols" after
applying an overlay with symbols.

Signed-off-by: Marcus Comstedt <marcus@mc.pp.se>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
