### PR TITLE
fastboot: reinit partition after storing GPT or MBR

### DIFF
--- a/drivers/fastboot/fb_mmc.c
+++ b/drivers/fastboot/fb_mmc.c
@@ -493,6 +493,7 @@ void fastboot_mmc_flash_write(const char *cmd, void *download_buffer,
 				      response);
 			return;
 		}
+		part_init(dev_desc);
 		printf("........ success\n");
 		fastboot_okay(NULL, response);
 		return;
@@ -514,6 +515,7 @@ void fastboot_mmc_flash_write(const char *cmd, void *download_buffer,
 				      response);
 			return;
 		}
+		part_init(dev_desc);
 		printf("........ success\n");
 		fastboot_okay(NULL, response);
 		return;


### PR DESCRIPTION
In case MMC has MBR system and fastboot writes GPT,
MMC is still recognized as MBR.
Invoke part_init() to purge cached data and update
information about partition table type.

Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
