### PR TITLE
properly load default environment when ENV_IS_NOWHERE is only env loc

### DIFF
--- a/env/env.c
+++ b/env/env.c
@@ -340,15 +340,15 @@ int env_init(void)
 			ret = -ENOENT;
 	}
 
-	if (!prio)
-		return -ENODEV;
-
 	if (ret == -ENOENT) {
 		gd->env_addr = (ulong)&default_environment[0];
 		gd->env_valid = ENV_VALID;
 
 		return 0;
 	}
+
+	if (!prio)
+		return -ENODEV;
 
 	return ret;
 }


### PR DESCRIPTION
Hi,

This patch makes sure we load the default environment when ENV_IS_NOWHERE is the only active ENV_IS_... config option.

Without the patch,
(drv = env_driver_lookup(ENVOP_INIT, prio))
evaluates to 0, causing prio = 0
Then, (!prio) is hit, returning -ENODEV causing a stall.

With the patch,
(drv = env_driver_lookup(ENVOP_INIT, prio))
evaluates to 0, causing prio = 0
Then, (ret == -ENOENT) is hit, causing default env to load with a return value of 0.
(!prio) is no longer hit