### PR TITLE
properly load default environment when ENV_IS_NOWHERE is only env loc…

### DIFF
--- a/env/env.c
+++ b/env/env.c
@@ -335,17 +335,18 @@ int env_init(void)
 
 		debug("%s: Environment %s init done (ret=%d)\n", __func__,
 		      drv->name, ret);
-
-		if (gd->env_valid == ENV_INVALID)
-			ret = -ENOENT;
 	}
 
-	if (!prio)
-		return -ENODEV;
+	if (!prio) {
+		gd->env_addr = (ulong)&default_environment[0];
+		gd->env_valid = ENV_INVALID;
+
+		return 0;
+	}
 
 	if (ret == -ENOENT) {
 		gd->env_addr = (ulong)&default_environment[0];
-		gd->env_valid = ENV_VALID;
+		gd->env_valid = ENV_INVALID;
 
 		return 0;
 	}


### PR DESCRIPTION
Hi,

This patch prevent u-boot from hanging on a UltraZed EG board (zynqmp).

Without the patch,
(drv = env_driver_lookup(ENVOP_INIT, prio))
evaluates to 0, causing prio = 0
Then, (!prio) is hit, returning -ENODEV causing a stall.

With the patch,
instead of returning -ENODEV and causing a stall, we
set gd->env_addr (is this really needed?)
and then
mark gd->env_valid = ENV_INVALID to use the default env.