### PR TITLE
cmd: pxe_utils: sysboot: fix crash if either board or soc are not set.

### DIFF
--- a/cmd/pxe_utils.c
+++ b/cmd/pxe_utils.c
@@ -587,6 +587,14 @@ static int label_boot(struct cmd_tbl *cmdtp, struct pxe_label *label)
 				f2 = "-";
 				f3 = env_get("board");
 				f4 = ".dtb";
+				if (!f1) {
+					f1 = "";
+					f2 = "";
+				}
+				if (!f3) {
+					f2 = "";
+					f3 = "";
+				}
 			}
 
 			len = strlen(label->fdtdir);


### PR DESCRIPTION
If the environment does not have "soc" or "board" set, and fdtdir
option is specified in extlinux.conf, the bootloader will crash whilst
dereferencing a null pointer. Add a guard against null soc or
board. Fixes a crash of qemu-riscv64_smode configuration, which does
not have CONFIG_SYS_SOC defined.

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
