### PR TITLE
gpio: Introduce CONFIG_GPIO_EXTRA_HEADER to cleanup #ifdefs

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -90,6 +90,9 @@ config HAS_VBAR
 config HAS_THUMB2
 	bool
 
+config GPIO_EXTRA_HEADER
+	bool
+
 # Used for compatibility with asm files copied from the kernel
 config ARM_ASM_UNIFIED
 	bool
@@ -518,25 +521,30 @@ choice
 
 config ARCH_AT91
 	bool "Atmel AT91"
+	select GPIO_EXTRA_HEADER
 	select SPL_BOARD_INIT if SPL && !TARGET_SMARTWEB
 	select SPL_SEPARATE_BSS if SPL
 
 config TARGET_EDB93XX
 	bool "Support edb93xx"
 	select CPU_ARM920T
+	select GPIO_EXTRA_HEADER
 	select PL010_SERIAL
 
 config TARGET_ASPENITE
 	bool "Support aspenite"
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 
 config TARGET_GPLUGD
 	bool "Support gplugd"
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 
 config ARCH_DAVINCI
 	bool "TI DaVinci"
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 	select SPL_DM_SPI if SPL
 	imply CMD_SAVES
 	help
@@ -547,6 +555,7 @@ config ARCH_KIRKWOOD
 	select ARCH_MISC_INIT
 	select BOARD_EARLY_INIT_F
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 
 config ARCH_MVEBU
 	bool "Marvell MVEBU family (Armada XP/375/38x/3700/7K/8K)"
@@ -555,6 +564,7 @@ config ARCH_MVEBU
 	select DM_SERIAL
 	select DM_SPI
 	select DM_SPI_FLASH
+	select GPIO_EXTRA_HEADER
 	select SPL_DM_SPI if SPL
 	select SPL_DM_SPI_FLASH if SPL
 	select OF_CONTROL
@@ -565,11 +575,13 @@ config ARCH_MVEBU
 config ARCH_ORION5X
 	bool "Marvell Orion"
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 
 config TARGET_SPEAR300
 	bool "Support spear300"
 	select BOARD_EARLY_INIT_F
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 	select PL011_SERIAL
 	imply CMD_SAVES
 
@@ -577,6 +589,7 @@ config TARGET_SPEAR310
 	bool "Support spear310"
 	select BOARD_EARLY_INIT_F
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 	select PL011_SERIAL
 	imply CMD_SAVES
 
@@ -584,6 +597,7 @@ config TARGET_SPEAR320
 	bool "Support spear320"
 	select BOARD_EARLY_INIT_F
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 	select PL011_SERIAL
 	imply CMD_SAVES
 
@@ -591,6 +605,7 @@ config TARGET_SPEAR600
 	bool "Support spear600"
 	select BOARD_EARLY_INIT_F
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 	select PL011_SERIAL
 	imply CMD_SAVES
 
@@ -601,6 +616,7 @@ config TARGET_STV0991
 	select DM_SERIAL
 	select DM_SPI
 	select DM_SPI_FLASH
+	select GPIO_EXTRA_HEADER
 	select PL01X_SERIAL
 	select SPI
 	select SPI_FLASH
@@ -610,18 +626,21 @@ config TARGET_X600
 	bool "Support x600"
 	select BOARD_LATE_INIT
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 	select PL011_SERIAL
 	select SUPPORT_SPL
 
 config TARGET_FLEA3
 	bool "Support flea3"
 	select CPU_ARM1136
+	select GPIO_EXTRA_HEADER
 
 config ARCH_BCM283X
 	bool "Broadcom BCM283X family"
 	select DM
 	select DM_GPIO
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	select PL01X_SERIAL
 	select SERIAL_SEARCH_ALL
@@ -650,6 +669,7 @@ config ARCH_BCMSTB
 	bool "Broadcom BCM7XXX family"
 	select CPU_V7A
 	select DM
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	select OF_PRIOR_STAGE
 	imply CMD_DM
@@ -660,6 +680,7 @@ config ARCH_BCMSTB
 config TARGET_BCMCYGNUS
 	bool "Support bcmcygnus"
 	select CPU_V7A
+	select GPIO_EXTRA_HEADER
 	imply BCM_SF2_ETH
 	imply BCM_SF2_ETH_GMAC
 	imply CMD_HASH
@@ -671,6 +692,7 @@ config TARGET_BCMCYGNUS
 config TARGET_BCMNS2
 	bool "Support Broadcom Northstar2"
 	select ARM64
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for Broadcom Northstar 2 SoCs.  NS2 is a quad-core 64-bit
 	  ARMv8 Cortex-A57 processors targeting a broad range of networking
@@ -695,6 +717,7 @@ config ARCH_EXYNOS
 	select DM_SPI
 	select DM_SPI_FLASH
 	select SPI
+	select GPIO_EXTRA_HEADER
 	imply SYS_THUMB_BUILD
 	imply CMD_DM
 	imply FAT_WRITE
@@ -706,6 +729,7 @@ config ARCH_S5PC1XX
 	select DM_GPIO
 	select DM_I2C
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	imply CMD_DM
 
 config ARCH_HIGHBANK
@@ -726,6 +750,7 @@ config ARCH_INTEGRATOR
 	bool "ARM Ltd. Integrator family"
 	select DM
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select PL01X_SERIAL
 	imply CMD_DM
 
@@ -736,6 +761,7 @@ config ARCH_IPQ40XX
 	select DM_GPIO
 	select DM_SERIAL
 	select DM_RESET
+	select GPIO_EXTRA_HEADER
 	select MSM_SMEM
 	select PINCTRL
 	select CLK
@@ -747,6 +773,7 @@ config ARCH_KEYSTONE
 	bool "TI Keystone"
 	select CMD_POWEROFF
 	select CPU_V7A
+	select GPIO_EXTRA_HEADER
 	select SUPPORT_SPL
 	select SYS_ARCH_TIMER
 	select SYS_THUMB_BUILD
@@ -763,6 +790,7 @@ config ARCH_K3
 config ARCH_OMAP2PLUS
 	bool "TI OMAP2+"
 	select CPU_V7A
+	select GPIO_EXTRA_HEADER
 	select SPL_BOARD_INIT if SPL
 	select SPL_STACK_R if SPL
 	select SUPPORT_SPL
@@ -771,6 +799,7 @@ config ARCH_OMAP2PLUS
 
 config ARCH_MESON
 	bool "Amlogic Meson"
+	select GPIO_EXTRA_HEADER
 	imply DISTRO_DEFAULTS
 	imply DM_RNG
 	help
@@ -781,6 +810,7 @@ config ARCH_MESON
 config ARCH_MEDIATEK
 	bool "MediaTek SoCs"
 	select DM
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	select SPL_DM if SPL
 	select SPL_LIBCOMMON_SUPPORT if SPL
@@ -797,6 +827,7 @@ config ARCH_LPC32XX
 	select DM
 	select DM_GPIO
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select SPL_DM if SPL
 	select SUPPORT_SPL
 	imply CMD_DM
@@ -805,12 +836,14 @@ config ARCH_IMX8
 	bool "NXP i.MX8 platform"
 	select ARM64
 	select DM
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	select ENABLE_ARM_SOC_BOOT0_HOOK
 
 config ARCH_IMX8M
 	bool "NXP i.MX8M platform"
 	select ARM64
+	select GPIO_EXTRA_HEADER
 	select SYS_FSL_HAS_SEC if IMX_HAB
 	select SYS_FSL_SEC_COMPAT_4
 	select SYS_FSL_SEC_LE
@@ -823,33 +856,39 @@ config ARCH_IMXRT
 	select CPU_V7M
 	select DM
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select SUPPORT_SPL
 	imply CMD_DM
 
 config ARCH_MX23
 	bool "NXP i.MX23 family"
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 	select PL011_SERIAL
 	select SUPPORT_SPL
 
 config ARCH_MX25
 	bool "NXP MX25"
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 	imply MXC_GPIO
 
 config ARCH_MX28
 	bool "NXP i.MX28 family"
 	select CPU_ARM926EJS
+	select GPIO_EXTRA_HEADER
 	select PL011_SERIAL
 	select SUPPORT_SPL
 
 config ARCH_MX31
 	bool "NXP i.MX31 family"
 	select CPU_ARM1136
+	select GPIO_EXTRA_HEADER
 
 config ARCH_MX7ULP
 	bool "NXP MX7ULP"
 	select CPU_V7A
+	select GPIO_EXTRA_HEADER
 	select SYS_FSL_HAS_SEC if IMX_HAB
 	select SYS_FSL_SEC_COMPAT_4
 	select SYS_FSL_SEC_LE
@@ -861,6 +900,7 @@ config ARCH_MX7
 	bool "Freescale MX7"
 	select ARCH_MISC_INIT
 	select CPU_V7A
+	select GPIO_EXTRA_HEADER
 	select SYS_FSL_HAS_SEC if IMX_HAB
 	select SYS_FSL_SEC_COMPAT_4
 	select SYS_FSL_SEC_LE
@@ -871,6 +911,7 @@ config ARCH_MX7
 config ARCH_MX6
 	bool "Freescale MX6"
 	select CPU_V7A
+	select GPIO_EXTRA_HEADER
 	select SYS_FSL_HAS_SEC
 	select SYS_FSL_SEC_COMPAT_4
 	select SYS_FSL_SEC_LE
@@ -886,18 +927,21 @@ config ARCH_MX5
 	bool "Freescale MX5"
 	select BOARD_EARLY_INIT_F
 	select CPU_V7A
+	select GPIO_EXTRA_HEADER
 	imply MXC_GPIO
 
 config ARCH_NEXELL
 	bool "Nexell S5P4418/S5P6818 SoC"
 	select ENABLE_ARM_SOC_BOOT0_HOOK
 	select DM
+	select GPIO_EXTRA_HEADER
 
 config ARCH_OWL
 	bool "Actions Semi OWL SoCs"
 	select DM
 	select DM_ETH
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select OWL_SERIAL
 	select CLK
 	select CLK_OWL
@@ -920,6 +964,7 @@ config ARCH_RMOBILE
 	bool "Renesas ARM SoCs"
 	select DM
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	imply BOARD_EARLY_INIT_F
 	imply CMD_DM
 	imply FAT_WRITE
@@ -932,6 +977,7 @@ config ARCH_SNAPDRAGON
 	select DM
 	select DM_GPIO
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select MSM_SMEM
 	select OF_CONTROL
 	select OF_SEPARATE
@@ -947,6 +993,7 @@ config ARCH_SOCFPGA
 	select CPU_V7A if TARGET_SOCFPGA_GEN5 || TARGET_SOCFPGA_ARRIA10
 	select DM
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select ENABLE_ARM_SOC_BOOT0_HOOK if TARGET_SOCFPGA_GEN5 || TARGET_SOCFPGA_ARRIA10
 	select OF_CONTROL
 	select SPL_DM_RESET if DM_RESET
@@ -998,6 +1045,7 @@ config ARCH_SUNXI
 	select DM_SCSI if SCSI
 	select DM_SERIAL
 	select DM_USB if DISTRO_DEFAULTS
+	select GPIO_EXTRA_HEADER
 	select OF_BOARD_SETUP
 	select OF_CONTROL
 	select OF_SEPARATE
@@ -1057,6 +1105,7 @@ config ARCH_VERSAL
 	select DM_ETH if NET
 	select DM_MMC if MMC
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	imply BOARD_LATE_INIT
 	imply ENV_VARS_UBOOT_RUNTIME_CONFIG
@@ -1064,6 +1113,7 @@ config ARCH_VERSAL
 config ARCH_VF610
 	bool "Freescale Vybrid"
 	select CPU_V7A
+	select GPIO_EXTRA_HEADER
 	select SYS_FSL_ERRATUM_ESDHC111
 	imply CMD_MTDPARTS
 	imply MTD_RAW_NAND
@@ -1080,6 +1130,7 @@ config ARCH_ZYNQ
 	select DM_SPI
 	select DM_SPI_FLASH
 	select DM_USB if USB
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	select SPI
 	select SPL_BOARD_INIT if SPL
@@ -1106,6 +1157,7 @@ config ARCH_ZYNQMP_R5
 	select DM_ETH if NET
 	select DM_MMC if MMC
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	imply CMD_DM
 	imply DM_USB_GADGET
@@ -1123,6 +1175,7 @@ config ARCH_ZYNQMP
 	select DM_SPI_FLASH if DM_SPI
 	select DM_USB if USB
 	select FIRMWARE
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	select SPL_BOARD_INIT if SPL
 	select SPL_CLK if SPL
@@ -1143,23 +1196,27 @@ config ARCH_ZYNQMP
 
 config ARCH_TEGRA
 	bool "NVIDIA Tegra"
+	select GPIO_EXTRA_HEADER
 	imply DISTRO_DEFAULTS
 	imply FAT_WRITE
 
 config TARGET_VEXPRESS64_AEMV8A
 	bool "Support vexpress_aemv8a"
 	select ARM64
+	select GPIO_EXTRA_HEADER
 	select PL01X_SERIAL
 
 config TARGET_VEXPRESS64_BASE_FVP
 	bool "Support Versatile Express ARMv8a FVP BASE model"
 	select ARM64
+	select GPIO_EXTRA_HEADER
 	select PL01X_SERIAL
 	select SEMIHOSTING
 
 config TARGET_VEXPRESS64_JUNO
 	bool "Support Versatile Express Juno Development Platform"
 	select ARM64
+	select GPIO_EXTRA_HEADER
 	select PL01X_SERIAL
 	select DM
 	select OF_CONTROL
@@ -1188,6 +1245,7 @@ config TARGET_LS2080A_EMU
 	select ARM64
 	select ARMV8_MULTIENTRY
 	select FSL_DDR_SYNC_REFRESH
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for Freescale LS2080A_EMU platform.
 	  The LS2080A Development System (EMULATOR) is a pre-silicon
@@ -1201,6 +1259,7 @@ config TARGET_LS1088AQDS
 	select ARMV8_MULTIENTRY
 	select ARCH_SUPPORT_TFABOOT
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	select SUPPORT_SPL
 	select FSL_DDR_INTERACTIVE if !SD_BOOT
 	help
@@ -1216,6 +1275,7 @@ config TARGET_LS2080AQDS
 	select ARMV8_MULTIENTRY
 	select ARCH_SUPPORT_TFABOOT
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	select SUPPORT_SPL
 	imply SCSI
 	imply SCSI_AHCI
@@ -1237,6 +1297,7 @@ config TARGET_LS2080ARDB
 	select SUPPORT_SPL
 	select FSL_DDR_BIST
 	select FSL_DDR_INTERACTIVE if !SPL
+	select GPIO_EXTRA_HEADER
 	imply SCSI
 	imply SCSI_AHCI
 	help
@@ -1251,6 +1312,7 @@ config TARGET_LS2081ARDB
 	select ARM64
 	select ARMV8_MULTIENTRY
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	select SUPPORT_SPL
 	help
 	  Support for Freescale LS2081ARDB platform.
@@ -1265,6 +1327,7 @@ config TARGET_LX2160ARDB
 	select ARMV8_MULTIENTRY
 	select ARCH_SUPPORT_TFABOOT
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for NXP LX2160ARDB platform.
 	  The lx2160ardb (LX2160A Reference design board (RDB)
@@ -1278,6 +1341,7 @@ config TARGET_LX2160AQDS
 	select ARMV8_MULTIENTRY
 	select ARCH_SUPPORT_TFABOOT
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for NXP LX2160AQDS platform.
 	  The lx2160aqds (LX2160A QorIQ Development System (QDS)
@@ -1292,6 +1356,7 @@ config TARGET_LX2162AQDS
 	select ARMV8_MULTIENTRY
 	select ARCH_SUPPORT_TFABOOT
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for NXP LX2162AQDS platform.
 	  The lx2162aqds support is based on LX2160A Layerscape Architecture processor.
@@ -1302,6 +1367,7 @@ config TARGET_HIKEY
 	select DM
 	select DM_GPIO
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	select PL01X_SERIAL
 	select SPECIFY_CONSOLE_INDEX
@@ -1315,6 +1381,7 @@ config TARGET_HIKEY960
 	select ARM64
 	select DM
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	select PL01X_SERIAL
 	imply CMD_DM
@@ -1328,6 +1395,7 @@ config TARGET_POPLAR
 	select DM
 	select DM_SERIAL
 	select DM_USB
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	select PL01X_SERIAL
 	imply CMD_DM
@@ -1343,6 +1411,7 @@ config TARGET_LS1012AQDS
 	select ARM64
 	select ARCH_SUPPORT_TFABOOT
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for Freescale LS1012AQDS platform.
 	  The LS1012A Development System (QDS) is a high-performance
@@ -1355,6 +1424,7 @@ config TARGET_LS1012ARDB
 	select ARM64
 	select ARCH_SUPPORT_TFABOOT
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	imply SCSI
 	imply SCSI_AHCI
 	help
@@ -1369,6 +1439,7 @@ config TARGET_LS1012A2G5RDB
 	select ARM64
 	select ARCH_SUPPORT_TFABOOT
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	imply SCSI
 	help
 	  Support for Freescale LS1012A2G5RDB platform.
@@ -1382,6 +1453,7 @@ config TARGET_LS1012AFRWY
 	select ARM64
 	select ARCH_SUPPORT_TFABOOT
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	imply SCSI
 	imply SCSI_AHCI
 	help
@@ -1395,6 +1467,7 @@ config TARGET_LS1012AFRDM
 	select ARCH_LS1012A
 	select ARM64
 	select ARCH_SUPPORT_TFABOOT
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for Freescale LS1012AFRDM platform.
 	  The LS1012A Freedom  board (FRDM) is a high-performance
@@ -1408,6 +1481,7 @@ config TARGET_LS1028AQDS
 	select ARMV8_MULTIENTRY
 	select ARCH_SUPPORT_TFABOOT
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for Freescale LS1028AQDS platform
 	  The LS1028A Development System (QDS) is a high-performance
@@ -1421,6 +1495,7 @@ config TARGET_LS1028ARDB
 	select ARMV8_MULTIENTRY
 	select ARCH_SUPPORT_TFABOOT
 	select BOARD_LATE_INIT
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for Freescale LS1028ARDB platform
 	  The LS1028A Development System (RDB) is a high-performance
@@ -1436,6 +1511,7 @@ config TARGET_LS1088ARDB
 	select BOARD_LATE_INIT
 	select SUPPORT_SPL
 	select FSL_DDR_INTERACTIVE if !SD_BOOT
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for NXP LS1088ARDB platform.
 	  The LS1088A Reference design board (RDB) is a high-performance
@@ -1456,6 +1532,7 @@ config TARGET_LS1021AQDS
 	select SYS_FSL_DDR
 	select FSL_DDR_INTERACTIVE
 	select DM_SPI_FLASH if FSL_DSPI || FSL_QSPI
+	select GPIO_EXTRA_HEADER
 	select SPI_FLASH_DATAFLASH if FSL_DSPI || FSL_QSPI
 	imply SCSI
 
@@ -1471,6 +1548,7 @@ config TARGET_LS1021ATWR
 	select LS1_DEEP_SLEEP
 	select SUPPORT_SPL
 	select DM_SPI_FLASH if FSL_DSPI || FSL_QSPI
+	select GPIO_EXTRA_HEADER
 	imply SCSI
 
 config TARGET_PG_WCOM_SELI8
@@ -1484,6 +1562,7 @@ config TARGET_PG_WCOM_SELI8
 	select CPU_V7_HAS_VIRT
 	select SYS_FSL_DDR
 	select FSL_DDR_INTERACTIVE
+	select GPIO_EXTRA_HEADER
 	select VENDOR_KM
 	imply SCSI
 	help
@@ -1502,6 +1581,7 @@ config TARGET_LS1021ATSN
 	select CPU_V7_HAS_VIRT
 	select LS1_DEEP_SLEEP
 	select SUPPORT_SPL
+	select GPIO_EXTRA_HEADER
 	imply SCSI
 
 config TARGET_LS1021AIOT
@@ -1514,6 +1594,7 @@ config TARGET_LS1021AIOT
 	select CPU_V7_HAS_VIRT
 	select SUPPORT_SPL
 	select DM_SPI_FLASH if FSL_DSPI || FSL_QSPI
+	select GPIO_EXTRA_HEADER
 	imply SCSI
 	help
 	  Support for Freescale LS1021AIOT platform.
@@ -1533,6 +1614,7 @@ config TARGET_LS1043AQDS
 	select FSL_DDR_INTERACTIVE if !SPL
 	select FSL_DSPI if !SPL_NO_DSPI
 	select DM_SPI_FLASH if FSL_DSPI
+	select GPIO_EXTRA_HEADER
 	imply SCSI
 	imply SCSI_AHCI
 	help
@@ -1549,6 +1631,7 @@ config TARGET_LS1043ARDB
 	select SUPPORT_SPL
 	select FSL_DSPI if !SPL_NO_DSPI
 	select DM_SPI_FLASH if FSL_DSPI
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for Freescale LS1043ARDB platform.
 
@@ -1565,6 +1648,7 @@ config TARGET_LS1046AQDS
 	select FSL_DDR_BIST if !SPL
 	select FSL_DDR_INTERACTIVE  if !SPL
 	select FSL_DDR_INTERACTIVE if !SPL
+	select GPIO_EXTRA_HEADER
 	imply SCSI
 	help
 	  Support for Freescale LS1046AQDS platform.
@@ -1585,6 +1669,7 @@ config TARGET_LS1046ARDB
 	select SUPPORT_SPL
 	select FSL_DDR_BIST
 	select FSL_DDR_INTERACTIVE if !SPL
+	select GPIO_EXTRA_HEADER
 	imply SCSI
 	help
 	  Support for Freescale LS1046ARDB platform.
@@ -1601,6 +1686,7 @@ config TARGET_LS1046AFRWY
 	select BOARD_EARLY_INIT_F
 	select BOARD_LATE_INIT
 	select DM_SPI_FLASH if DM_SPI
+	select GPIO_EXTRA_HEADER
 	imply SCSI
 	help
 	  Support for Freescale LS1046AFRWY platform.
@@ -1629,6 +1715,7 @@ config TARGET_SL28
 	select DM_SERIAL
 	select DM_SPI
 	select DM_USB
+	select GPIO_EXTRA_HEADER
 	select SPL_DM if SPL
 	select SPL_DM_SPI if SPL
 	select SPL_DM_SPI_FLASH if SPL
@@ -1641,6 +1728,7 @@ config TARGET_SL28
 config TARGET_COLIBRI_PXA270
 	bool "Support colibri_pxa270"
 	select CPU_PXA
+	select GPIO_EXTRA_HEADER
 
 config ARCH_UNIPHIER
 	bool "Socionext UniPhier SoCs"
@@ -1677,6 +1765,7 @@ config ARCH_STM32
 	select CPU_V7M
 	select DM
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	imply CMD_DM
 
 config ARCH_STI
@@ -1702,6 +1791,7 @@ config ARCH_STM32MP
 	select DM_GPIO
 	select DM_RESET
 	select DM_SERIAL
+	select GPIO_EXTRA_HEADER
 	select MISC
 	select OF_CONTROL
 	select OF_LIBFDT
@@ -1764,6 +1854,7 @@ config ARCH_OCTEONTX
 	bool "Support OcteonTX SoCs"
 	select CLK
 	select DM
+	select GPIO_EXTRA_HEADER
 	select ARM64
 	select OF_CONTROL
 	select OF_LIVE
@@ -1774,6 +1865,7 @@ config ARCH_OCTEONTX2
 	bool "Support OcteonTX2 SoCs"
 	select CLK
 	select DM
+	select GPIO_EXTRA_HEADER
 	select ARM64
 	select OF_CONTROL
 	select OF_LIVE
@@ -1783,6 +1875,7 @@ config ARCH_OCTEONTX2
 config TARGET_THUNDERX_88XX
 	bool "Support ThunderX 88xx"
 	select ARM64
+	select GPIO_EXTRA_HEADER
 	select OF_CONTROL
 	select PL01X_SERIAL
 	select SYS_CACHE_SHIFT_7
@@ -1796,6 +1889,7 @@ config ARCH_ASPEED
 config TARGET_DURIAN
 	bool "Support Phytium Durian Platform"
 	select ARM64
+	select GPIO_EXTRA_HEADER
 	help
 	  Support for durian platform.
 	  It has 2GB Sdram, uart and pcie.

--- a/arch/arm/include/asm/gpio.h
+++ b/arch/arm/include/asm/gpio.h
@@ -1,10 +1,4 @@
-#if !defined(CONFIG_ARCH_UNIPHIER) && !defined(CONFIG_ARCH_STI) && \
-	!defined(CONFIG_ARCH_K3) && !defined(CONFIG_ARCH_BCM68360) && \
-	!defined(CONFIG_ARCH_BCM6858) && !defined(CONFIG_ARCH_BCM63158) && \
-	!defined(CONFIG_ARCH_ROCKCHIP) && !defined(CONFIG_ARCH_ASPEED) && \
-	!defined(CONFIG_ARCH_U8500) && !defined(CONFIG_CORTINA_PLATFORM) && \
-	!defined(CONFIG_TARGET_BCMNS3) && !defined(CONFIG_TARGET_TOTAL_COMPUTE) && \
-	!defined(CONFIG_ARCH_QEMU)
+#ifdef CONFIG_GPIO_EXTRA_HEADER
 #include <asm/arch/gpio.h>
 #endif
 #include <asm-generic/gpio.h>


### PR DESCRIPTION
Since some SoCs and boards do not hae extra asm/arch/gpio.h,
introduce CONFIG_GPIO_EXTRA_HEADER instead of adding
!define(CONFIG_ARCH_XXXX) in asm/gpio.h.

Signed-off-by: Masami Hiramatsu <masami.hiramatsu@linaro.org>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
