### PR TITLE
Fix flash and erase of EMMC_BOOT2 with fastboot

### DIFF
--- a/drivers/fastboot/fb_mmc.c
+++ b/drivers/fastboot/fb_mmc.c
@@ -525,7 +525,7 @@ void fastboot_mmc_flash_write(const char *cmd, void *download_buffer,
 	if (strcmp(cmd, CONFIG_FASTBOOT_MMC_BOOT2_NAME) == 0) {
 		dev_desc = fastboot_mmc_get_dev(response);
 		if (dev_desc)
-			fb_mmc_boot_ops(dev_desc, download_buffer, 1,
+			fb_mmc_boot_ops(dev_desc, download_buffer, 2,
 					download_bytes, response);
 		return;
 	}
@@ -655,7 +655,7 @@ void fastboot_mmc_erase(const char *cmd, char *response)
 		/* erase EMMC boot2 */
 		dev_desc = fastboot_mmc_get_dev(response);
 		if (dev_desc)
-			fb_mmc_boot_ops(dev_desc, NULL, 1, 0, response);
+			fb_mmc_boot_ops(dev_desc, NULL, 2, 0, response);
 		return;
 	}
 #endif


### PR DESCRIPTION
The current U-Boot version has the next matches for boot partitions:
> mmc0boot0 to EMMC_BOOT1
> mmc0boot1 to EMMC_BOOT1 (should be EMMC_BOOT2)
This patch fixes a typo for the boot partition number.

Signed-off-by: Oleh Kravchenko <oleg@kaa.org.ua>
Cc: Pantelis Antoniou <panto@antoniou-consulting.com>
Cc: Marek Vasut <marex@denx.de>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
