### PR TITLE
test/py: Let tests fallback to sudo when libguestfs tools fail

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -293,6 +293,11 @@ jobs:
               wget -O - https://github.com/riscv/opensbi/releases/download/v0.9/opensbi-0.9-rv-bin.tar.xz | tar -C /tmp -xJ;
               export OPENSBI=/tmp/opensbi-0.9-rv-bin/share/opensbi/lp64/generic/firmware/fw_dynamic.bin;
           fi
+          if [[ "${TEST_PY_BD}" == "sandbox" ]]; then
+              sudo apt update
+              sudo apt install -y linux-image-kvm
+              sudo chmod +r /boot/vmlinu* /lib/modules/*/vmlinu* || true
+          fi
           # the below corresponds to .gitlab-ci.yml "script"
           cd ${WORK_DIR}
           export UBOOT_TRAVIS_BUILD_DIR=/tmp/${TEST_PY_BD};

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -318,7 +318,15 @@ jobs:
           # as sandbox testing need create files like spi flash images, etc.
           # (TODO: clean up this in the future)
           chmod 777 .
-          docker run -v $PWD:$(work_dir) $(ci_runner_image) /bin/bash $(work_dir)/test.sh
+          # Some EFI tests need extra docker args to run
+          set --
+          if [[ "${TEST_PY_BD}" == "sandbox" ]]; then
+              # virt-make-fs needs the fuse device
+              if modprobe fuse; then
+                  set -- "$@" --device /dev/fuse:/dev/fuse
+              fi
+          fi
+          docker run "$@" -v $PWD:$(work_dir) $(ci_runner_image) /bin/bash $(work_dir)/test.sh
 
   - job: build_the_world
     displayName: 'Build the World'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -318,13 +318,23 @@ jobs:
           # as sandbox testing need create files like spi flash images, etc.
           # (TODO: clean up this in the future)
           chmod 777 .
-          # Some EFI tests need extra docker args to run
+          # Filesystem tests and some EFI tests need extra docker args to run
           set --
           if [[ "${TEST_PY_BD}" == "sandbox" ]]; then
-              # virt-make-fs needs the fuse device
+              # virt-make-fs, guestmount, etc. need the fuse device
               if modprobe fuse; then
                   set -- "$@" --device /dev/fuse:/dev/fuse
               fi
+              # mount -o loop needs the loop devices
+              if modprobe loop; then
+                  for d in $(find /dev -maxdepth 1 -name 'loop*'); do
+                      set -- "$@" --device $d:$d
+                  done
+              fi
+              # Needed for mount syscall (for guestmount as well)
+              set -- "$@" --cap-add SYS_ADMIN
+              # Default apparmor profile denies mounts
+              set -- "$@" --security-opt apparmor=unconfined
           fi
           docker run "$@" -v $PWD:$(work_dir) $(ci_runner_image) /bin/bash $(work_dir)/test.sh
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,11 @@ stages:
         wget -O - https://github.com/riscv/opensbi/releases/download/v0.9/opensbi-0.9-rv-bin.tar.xz | tar -C /tmp -xJ;
         export OPENSBI=/tmp/opensbi-0.9-rv-bin/share/opensbi/lp64/generic/firmware/fw_dynamic.bin;
       fi
+    - if [[ "${TEST_PY_BD}" == "sandbox" ]]; then
+        sudo apt update;
+        sudo apt install -y linux-image-kvm;
+        sudo chmod +r /boot/vmlinu* /lib/modules/*/vmlinu* || true;
+      fi
 
   after_script:
     - rm -rf /tmp/uboot-test-hooks /tmp/venv

--- a/test/py/tests/test_fs/conftest.py
+++ b/test/py/tests/test_fs/conftest.py
@@ -205,24 +205,23 @@ def mount_fs(fs_type, device, mount_point):
     """
     global fuse_mounted
 
-    fuse_mounted = False
     try:
-        if tool_is_in_path('guestmount'):
-            fuse_mounted = True
-            check_call('guestmount -a %s -m /dev/sda %s'
-                % (device, mount_point), shell=True)
-        else:
-            mount_opt = 'loop,rw'
-            if re.match('fat', fs_type):
-                mount_opt += ',umask=0000'
-
-            check_call('sudo mount -o %s %s %s'
-                % (mount_opt, device, mount_point), shell=True)
-
-            # may not be effective for some file systems
-            check_call('sudo chmod a+rw %s' % mount_point, shell=True)
+        check_call('guestmount -a %s -m /dev/sda %s'
+            % (device, mount_point), shell=True)
+        fuse_mounted = True
+        return
     except CalledProcessError:
-        raise
+        fuse_mounted = False
+
+    mount_opt = 'loop,rw'
+    if re.match('fat', fs_type):
+        mount_opt += ',umask=0000'
+
+    check_call('sudo mount -o %s %s %s'
+        % (mount_opt, device, mount_point), shell=True)
+
+    # may not be effective for some file systems
+    check_call('sudo chmod a+rw %s' % mount_point, shell=True)
 
 def umount_fs(mount_point):
     """Unmount a volume.

--- a/test/py/tests/test_fs/conftest.py
+++ b/test/py/tests/test_fs/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import re
 from subprocess import call, check_call, check_output, CalledProcessError
 from fstest_defs import *
+import u_boot_utils as util
 
 supported_fs_basic = ['fat16', 'fat32', 'ext4']
 supported_fs_ext = ['fat16', 'fat32']
@@ -206,7 +207,7 @@ def mount_fs(fs_type, device, mount_point):
     global fuse_mounted
 
     try:
-        check_call('guestmount -a %s -m /dev/sda %s'
+        check_call('guestmount --pid-file guestmount.pid -a %s -m /dev/sda %s'
             % (device, mount_point), shell=True)
         fuse_mounted = True
         return
@@ -235,6 +236,16 @@ def umount_fs(mount_point):
     if fuse_mounted:
         call('sync')
         call('guestunmount %s' % mount_point, shell=True)
+
+        try:
+            with open("guestmount.pid", "r") as pidfile:
+                pid = int(pidfile.read())
+            util.waitpid(pid, kill=True)
+            os.remove("guestmount.pid")
+
+        except FileNotFoundError:
+            pass
+
     else:
         call('sudo umount %s' % mount_point, shell=True)
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -71,6 +71,7 @@ RUN apt-get update && apt-get install -y \
 	libssl-dev \
 	libudev-dev \
 	libusb-1.0-0-dev \
+	linux-image-kvm \
 	lzma-alone \
 	lzop \
 	mount \
@@ -98,6 +99,9 @@ RUN apt-get update && apt-get install -y \
 	virtualenv \
 	zip \
 	&& rm -rf /var/lib/apt/lists/*
+
+# Make kernels readable for libguestfs tools to work correctly
+RUN chmod +r /boot/vmlinu* /lib/modules/*/vmlinu* || true
 
 # Manually install libmpfr4 for the toolchains
 RUN wget http://mirrors.kernel.org/ubuntu/pool/main/m/mpfr4/libmpfr4_3.1.4-1_amd64.deb && dpkg -i libmpfr4_3.1.4-1_amd64.deb && rm libmpfr4_3.1.4-1_amd64.deb


### PR DESCRIPTION
>Please do not submit a Pull Request via github.  Our project makes use of
>mailing lists for patch submission and review.  For more details please
>see https://www.denx.de/wiki/U-Boot/Patches

>The only exception to this is in order to trigger a CI loop on Azure prior
>to posting of patches.

This series is intended to let CIs run some tests they are currently skipping, so I wanted to test on a real one.