### PR TITLE
nvme: Remove the redundant aqa value setting

### DIFF
--- a/drivers/nvme/nvme.c
+++ b/drivers/nvme/nvme.c
@@ -379,7 +379,6 @@ static int nvme_configure_admin_queue(struct nvme_dev *dev)
 
 	aqa = nvmeq->q_depth - 1;
 	aqa |= aqa << 16;
-	aqa |= aqa << 16;
 
 	dev->page_size = 1 << page_shift;
 


### PR DESCRIPTION
AQA (Admin Queue Attributes) register is a dword size with
lower word of ASQS, and higher word of ACQS.

The code set the variable aqa twice, but it is redundant.

Signed-off-by: wesleywesley <wesleyshenggit@sina.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
