### PR TITLE
nvme: correct the prps per page calculation method

### DIFF
--- a/drivers/nvme/nvme.c
+++ b/drivers/nvme/nvme.c
@@ -79,7 +79,7 @@ static int nvme_setup_prps(struct nvme_dev *dev, u64 *prp2,
 	u64 *prp_pool;
 	int length = total_len;
 	int i, nprps;
-	u32 prps_per_page = (page_size >> 3) - 1;
+	u32 prps_per_page = page_size >> 3;
 	u32 num_pages;
 
 	length -= (page_size - offset);


### PR DESCRIPTION
Each prp is 8 bytes, calculate the number of prps
per page should just divide page size by 8
there is no need to minus 1

Signed-off-by: wesleywesley <wesleyshenggit@sina.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
