### PR TITLE
CI env: Make _init() expect _INVALID when _IS_NOWHERE

### DIFF
--- a/env/env.c
+++ b/env/env.c
@@ -336,7 +336,7 @@ int env_init(void)
 		debug("%s: Environment %s init done (ret=%d)\n", __func__,
 		      drv->name, ret);
 
-		if (gd->env_valid == ENV_INVALID)
+		if (gd->env_valid == ENV_INVALID && drv->location != ENVL_NOWHERE)
 			ret = -ENOENT;
 	}
 


### PR DESCRIPTION
Trigger a CI loop on Azure prior to posting of patches.
