### PR TITLE
efi_loader: split efi_init_obj_list() into two stages

### DIFF
--- a/common/board_r.c
+++ b/common/board_r.c
@@ -789,7 +789,7 @@ static init_fnc_t init_sequence_r[] = {
 	initr_mem,
 #endif
 #ifdef CONFIG_EFI_SETUP_EARLY
-	(init_fnc_t)efi_init_obj_list,
+	efi_init_early,
 #endif
 	run_main_loop,
 };

--- a/common/main.c
+++ b/common/main.c
@@ -54,8 +54,11 @@ void main_loop(void)
 	if (IS_ENABLED(CONFIG_UPDATE_TFTP))
 		update_tftp(0UL, NULL, NULL);
 
-	if (IS_ENABLED(CONFIG_EFI_CAPSULE_ON_DISK_EARLY))
-		efi_launch_capsules();
+	if (IS_ENABLED(CONFIG_EFI_CAPSULE_ON_DISK_EARLY)) {
+		/* efi_init_early() already called */
+		if (efi_init_obj_list() == EFI_SUCCESS)
+			efi_launch_capsules();
+	}
 
 	s = bootdelay_process();
 	if (cli_process_fdt(&s))

--- a/include/efi_loader.h
+++ b/include/efi_loader.h
@@ -491,6 +491,8 @@ struct efi_register_notify_event {
 /* List of all events registered by RegisterProtocolNotify() */
 extern struct list_head efi_register_notify_events;
 
+/* called at pre-initialization */
+int efi_init_early(void);
 /* Initialize efi execution environment */
 efi_status_t efi_init_obj_list(void);
 /* Install device tree */


### PR DESCRIPTION
In the next commit, CONFIG_EFI_SETUP_EARLY will become mandated
in order to support dynamic enumeration of efi_disk objects.

This can, however, be problematic particularly in case of file-based
variable storage (efi_variable.c, default).
Non-volatile variables are to be restored from EFI system partition
by efi_init_variables() in efi_init_obj_list(). When efi_init_obj_list()
is called in board_init_r(), we don't know yet what disk devices
we have since none of device probing commands (say, scsi rescan) has not
been executed at that stage.

So in this commit, a preparatory change is made; efi_init_obj_list() is
broken into the two functions;
   * efi_init_early(), and
   * new efi_init_obj_list()

Only efi_init_early() will be called in board_init_r(), which allows
us to execute any of device probing commands, either though "preboot"
variable or normal command line, before calling efi_init_obj_list() which
is to be invoked at the first execution of an efi-related command
(or at efi_launch_capsules()) as used to be.

Signed-off-by: AKASHI Takahiro <takahiro.akashi@linaro.org>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
