### PR TITLE
 tools: 1. `%m` is not handled properly by `sscanf` on some uClibc version; 2. free `line` only if `line` is not `NULL`.

### DIFF
--- a/tools/env/fw_env.c
+++ b/tools/env/fw_env.c
@@ -1787,10 +1787,11 @@ static int get_config(char *fname)
 {
 	FILE *fp;
 	int i = 0;
-	int rc;
+	int rc = 0;
 	char *line = NULL;
 	size_t linesize = 0;
-	char *devname;
+	size_t bufsize = linesize;
+	char *devname = NULL;
 
 	fp = fopen(fname, "r");
 	if (fp == NULL)
@@ -1801,10 +1802,16 @@ static int get_config(char *fname)
 		if (line[0] == '#')
 			continue;
 
-		rc = sscanf(line, "%ms %lli %lx %lx %lx",
-			    &devname,
-			    &DEVOFFSET(i),
-			    &ENVSIZE(i), &DEVESIZE(i), &ENVSECTORS(i));
+		if (!devname || linesize > bufsize) {
+			devname = realloc(devname, linesize);
+			if (devname)
+				bufsize = linesize;
+		}
+		if (devname)
+			rc = sscanf(line, "%s %lli %lx %lx %lx",
+						&devname,
+						&DEVOFFSET(i),
+						&ENVSIZE(i), &DEVESIZE(i), &ENVSECTORS(i));
 
 		if (rc < 3)
 			continue;
@@ -1817,7 +1824,8 @@ static int get_config(char *fname)
 
 		i++;
 	}
-	free(line);
+	if (line)
+		free(line);
 	fclose(fp);
 
 	have_redund_env = i - 1;


### PR DESCRIPTION
tools: 1. `%m` is not handled properly by `sscanf` on some uClibc version

 It casued the config file '/etc/fw_env.config' parse error:
 > Cannot parse config file '/etc/fw_env.config': Invalid argument

 It works well on uClibc 0.9.33.2 version after patched.

 2. free `line` only if `line` is not `NULL`.
