### PR TITLE
CVE-2022-30767: unbounded memcpy with a failed length check

### DIFF
--- a/net/nfs.c
+++ b/net/nfs.c
@@ -566,8 +566,6 @@ static int nfs_lookup_reply(uchar *pkt, unsigned len)
 	}
 
 	if (supported_nfs_versions & NFSV2_FLAG) {
-		if (((uchar *)&(rpc_pkt.u.reply.data[0]) - (uchar *)(&rpc_pkt) + NFS_FHSIZE) > len)
-			return -NFS_RPC_DROP;
 		memcpy(filefh, rpc_pkt.u.reply.data + 1, NFS_FHSIZE);
 	} else {  /* NFSV3_FLAG */
 		filefh3_length = ntohl(rpc_pkt.u.reply.data[1]);


### PR DESCRIPTION
This patch tries to fix a CVE-2019-14196 fix

In if-condition, where NFSV2_FLAG is checked, memcpy call is performed
to transfer a reply data of NFS_FHSIZE size. Since the data field in
struct rpc_t structure has the size of (1024 / 4) + 26 = 282, while
NFS_FHSIZE is only 32, it won't lead to out-of-bounds write (considering
the size of data array won't change in the future). So the memcpy call
will copy exactly NFS_FHSIZE (32) bytes from (rpc_pkt.u.reply.data + 1).

Signed-off-by: gerbert <gerbert@users.noreply.github.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
