### PR TITLE
Add 4 optional(default no) build config for riscv

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -144,6 +144,34 @@ config SPL_RISCV_SMODE
 
 endchoice
 
+config RISCV_ISA_F
+	bool "Single precision instructions"
+	help
+	  Adds "F" to the ISA subsets that the toolchain is allowed to emit
+	  when building U-Boot, which results in single precision floating point
+	  instructions in the U-Boot binary.
+
+config RISCV_ISA_D
+	bool "Double precision instructions"
+	help
+	  Adds "D" to the ISA subsets that the toolchain is allowed to emit
+	  when building U-Boot, which results in double precision floating point
+	  instructions in the U-Boot binary.
+
+config RISCV_ISA_ZICSR
+	bool "Control and status register instructions"
+	help
+	  Adds "ZICSR" to the ISA subsets that the toolchain is allowed to emit
+	  when building U-Boot, which results in control and status Register
+	  instructions in the U-Boot binary, since gcc 12.x and riscv spec 20191213.
+
+config RISCV_ISA_ZIFENCEI
+	bool "Instruction-fetch fence instructions"
+	help
+	  Adds "ZIFENCEI" to the ISA subsets that the toolchain is allowed to emit
+	  when building U-Boot, which results in instruction-fetch fence instructions
+	  in the U-Boot binary, since gcc 12.x and riscv spec 20191213.
+
 config RISCV_ISA_C
 	bool "Emit compressed instructions"
 	default y

--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -14,8 +14,24 @@ endif
 ifeq ($(CONFIG_RISCV_ISA_A),y)
 	ARCH_A = a
 endif
+ifeq ($(CONFIG_RISCV_ISA_F),y)
+	ARCH_F = f
+ifneq ($(CONFIG_RISCV_ISA_D),y)
+	ABI_FP_SUFFIX = $(ARCH_F)
+endif
+endif
+ifeq ($(CONFIG_RISCV_ISA_D),y)
+	ARCH_D = d
+	ABI_FP_SUFFIX = $(ARCH_D)
+endif
 ifeq ($(CONFIG_RISCV_ISA_C),y)
 	ARCH_C = c
+endif
+ifeq ($(CONFIG_RISCV_ISA_ZICSR),y)
+	ARCH_ZICSR = _zicsr
+endif
+ifeq ($(CONFIG_RISCV_ISA_ZIFENCEI),y)
+	ARCH_ZIFENCEI = _zifencei
 endif
 ifeq ($(CONFIG_CMODEL_MEDLOW),y)
 	CMODEL = medlow
@@ -24,8 +40,8 @@ ifeq ($(CONFIG_CMODEL_MEDANY),y)
 	CMODEL = medany
 endif
 
-ARCH_FLAGS = -march=$(ARCH_BASE)$(ARCH_A)$(ARCH_C) -mabi=$(ABI) \
-	     -mcmodel=$(CMODEL)
+ARCH_FLAGS = -march=$(ARCH_BASE)$(ARCH_A)$(ARCH_F)$(ARCH_D)$(ARCH_C)$(ARCH_ZICSR)$(ARCH_ZIFENCEI) \
+	-mabi=$(ABI)$(ABI_FP_SUFFIX) -mcmodel=$(CMODEL)
 
 PLATFORM_CPPFLAGS	+= $(ARCH_FLAGS)
 CFLAGS_EFI		+= $(ARCH_FLAGS)


### PR DESCRIPTION
* The riscv spec has breaking change from 2.2 to 20191213.
* Both ZICSR and ZIFENCEI are separated extension since 20191213 instead of RVI.
* Gcc bumpup the riscv spec to 20191213 since 12.x.
* To make it work, add below 4 option(default no) build option for compatibility.
* CONFIG_RISCV_ISA_F for single float point, default no.
* CONFIG_RISCV_ISA_D for double float point, default no.
* CONFIG_RISCV_ISA_ZICSR for control and status register, default no.
* CONFIG_RISCV_ISA_ZIFENCEI for instruction-fetch fence, default no.
* Example when build with gcc 12.x.
     make qemu-riscv64_defconfig && make CROSS_COMPILE=riscv64-linux-gnu- ARCH=riscv \
        CONFIG_RISCV_ISA_F=y \
        CONFIG_RISCV_ISA_D=y \
        CONFIG_RISCV_ISA_ZICSR=y \
        CONFIG_RISCV_ISA_ZIFENCEI=y

Signed-off-by: Pan Li <pan2.li@intel.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
