### PR TITLE
removal of setuptools.extern

### DIFF
--- a/scripts/dtc/pylibfdt/setup.py
+++ b/scripts/dtc/pylibfdt/setup.py
@@ -22,7 +22,7 @@ allows this script to be run stand-alone, e.g.:
 
 from setuptools import setup, Extension
 from setuptools.command.build_py import build_py as _build_py
-from setuptools.extern.packaging import version
+from packaging import version
 import os
 import re
 import sys


### PR DESCRIPTION
Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.

hi . my PR may not be used as a PR but more of a note about your commit : https://github.com/u-boot/u-boot/commit/440098c42e7369f4b5703a82723b2ce268180a1f .
on Gentoo and Arch we are removing that module because it breaks unvendored deps.

see this topic on gentoo forums : https://forums.gentoo.org/viewtopic-t-1160200.html

regards hedmo