### PR TITLE
doc: build infodocs target on Gitlab CI, Azure -- Trigger Azure CI -- Don't merge

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -76,8 +76,8 @@ stages:
     steps:
       - script: cppcheck -j$(nproc) --force --quiet --inline-suppr .
 
-  - job: htmldocs
-    displayName: 'Build HTML documentation'
+  - job: docs
+    displayName: 'Build documentation'
     pool:
       vmImage: $(ubuntu_vm)
     container:
@@ -89,6 +89,7 @@ stages:
           . /tmp/venvhtml/bin/activate
           pip install -r doc/sphinx/requirements.txt
           make htmldocs
+          make infodocs
 
   - job: todo
     displayName: 'Search for TODO within source tree'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,14 +149,15 @@ grep TODO/FIXME/HACK:
     # search for HACK within source tree and ignore HACKKIT board
     - grep -r HACK . | grep -v HACKKIT
 
-# build HTML documentation
-htmldocs:
+# build documentation
+docs:
   stage: testsuites
   script:
     - virtualenv -p /usr/bin/python3 /tmp/venvhtml
     - . /tmp/venvhtml/bin/activate
     - pip install -r doc/sphinx/requirements.txt
     - make htmldocs
+    - make infodocs
 
 # some statistics about the code base
 sloccount:


### PR DESCRIPTION
Add infodocs target to CI testing.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
