### PR TITLE
unit-test: fix undefined usb_started symbol

### DIFF
--- a/test/boot/Makefile
+++ b/test/boot/Makefile
@@ -2,7 +2,10 @@
 #
 # Copyright 2021 Google LLC
 
-obj-$(CONFIG_BOOTSTD) += bootdev.o bootstd_common.o bootflow.o bootmeth.o
+obj-$(CONFIG_BOOTSTD) += bootstd_common.o bootflow.o bootmeth.o
+ifdef CONFIG_USB
+obj-$(CONFIG_BOOTSTD) += bootdev.o
+endif
 obj-$(CONFIG_FIT) += image.o
 
 obj-$(CONFIG_EXPO) += expo.o


### PR DESCRIPTION
Reproduced by enabling CONFIG_UNIT_TEST=y for arch-meson related board. host/bin/aarch64-buildroot-linux-gnu-ld.bfd:
    test/boot/bootdev.o: in function `bootdev_test_prio':
build/uboot-custom/test/boot/bootdev.c:194: undefined reference to
    `usb_started'
host/bin/aarch64-buildroot-linux-gnu-ld.bfd: test/boot/bootdev.o:
    relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `usb_started'
    which may bind externally can not be used when making a shared
    object; recompile with -fPIC
build/uboot-custom/test/boot/bootdev.c:194:(.text.bootdev_test_prio+0x18):
    dangerous relocation: unsupported relocation
host/bin/aarch64-buildroot-linux-gnu-ld.bfd: test/boot/bootdev.c:194:
    undefined reference to `usb_started'

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
