### PR TITLE
Update rk3399_common.h

### DIFF
--- a/include/configs/rk3399_common.h
+++ b/include/configs/rk3399_common.h
@@ -48,6 +48,8 @@
 #define ROCKCHIP_DEVICE_SETTINGS
 #endif
 
+#include <config_distro_bootcmd.h>
+#include <environment/distro/sf.h>
 #define CFG_EXTRA_ENV_SETTINGS \
 	ENV_MEM_LAYOUT_SETTINGS \
 	"fdtfile=" CONFIG_DEFAULT_FDT_FILE "\0" \
@@ -56,8 +58,9 @@
 	"boot_targets=" BOOT_TARGETS "\0" \
 	"altbootcmd=" \
 		"setenv boot_syslinux_conf extlinux/extlinux-rollback.conf;" \
-		"run distro_bootcmd\0"
-
+		"run distro_bootcmd\0" \
+	BOOTENV \
+	BOOTENV_SF
 #endif
 
 #endif


### PR DESCRIPTION
The new rk3399_common.h missed the BOOTENV which is defined in include/config_distro_bootcmd.h file. It will lead to the error of "undefined distro_bootcmd" which lacks the setting of environment variables.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
