### PR TITLE
common/memsize.c: Fix get_ram_size() when cache is enabled

### DIFF
--- a/arch/sandbox/cpu/cpu.c
+++ b/arch/sandbox/cpu/cpu.c
@@ -286,6 +286,11 @@ void sandbox_set_enable_pci_map(int enable)
 	enable_pci_map = enable;
 }
 
+int dcache_status(void)
+{
+	return true;
+}
+
 void flush_dcache_range(unsigned long start, unsigned long stop)
 {
 }

--- a/common/memsize.c
+++ b/common/memsize.c
@@ -7,8 +7,17 @@
 #include <common.h>
 #include <init.h>
 #include <asm/global_data.h>
+#include <cpu_func.h>
+#include <stdint.h>
 
 DECLARE_GLOBAL_DATA_PTR;
+
+#ifdef CONFIG_SYS_CACHELINE_SIZE
+# define MEMSIZE_CACHELINE_SIZE CONFIG_SYS_CACHELINE_SIZE
+#else
+/* Just use the greatest cache flush alignment requirement I'm aware of */
+# define MEMSIZE_CACHELINE_SIZE 128
+#endif
 
 #ifdef __PPC__
 /*
@@ -19,6 +28,15 @@ DECLARE_GLOBAL_DATA_PTR;
 #else
 # define sync()		/* nothing */
 #endif
+
+static void dcache_flush_invalidate(volatile long *p)
+{
+	uintptr_t start, stop;
+	start = ALIGN_DOWN((uintptr_t)p, MEMSIZE_CACHELINE_SIZE);
+	stop = start + MEMSIZE_CACHELINE_SIZE;
+	flush_dcache_range(start, stop);
+	invalidate_dcache_range(start, stop);
+}
 
 /*
  * Check memory range for valid RAM. A simple memory test determines
@@ -34,6 +52,7 @@ long get_ram_size(long *base, long maxsize)
 	long           val;
 	long           size;
 	int            i = 0;
+	int            cache_flush = dcache_status();
 
 	for (cnt = (maxsize / sizeof(long)) >> 1; cnt > 0; cnt >>= 1) {
 		addr = base + cnt;	/* pointer arith! */
@@ -41,6 +60,8 @@ long get_ram_size(long *base, long maxsize)
 		save[i++] = *addr;
 		sync();
 		*addr = ~cnt;
+		if (cache_flush)
+			dcache_flush_invalidate(addr);
 	}
 
 	addr = base;
@@ -50,6 +71,9 @@ long get_ram_size(long *base, long maxsize)
 	*addr = 0;
 
 	sync();
+	if (cache_flush)
+		dcache_flush_invalidate(addr);
+
 	if ((val = *addr) != 0) {
 		/* Restore the original data before leaving the function. */
 		sync();

--- a/test/lib/test_crc8.c
+++ b/test/lib/test_crc8.c
@@ -5,6 +5,7 @@
  * Unit test for crc8
  */
 
+#include <errno.h>
 #include <test/lib.h>
 #include <test/ut.h>
 #include <u-boot/crc.h>


### PR DESCRIPTION
Ensure that every write is flushed to memory and afterward reads are from memory.
Since the algorithm rely on the fact that accessing to not existent memory lead to write at addr / 2 without this modification accesses to aliased (not physically present) addresses are cached and wrong size is returned.

This was discovered while working on a TI AM625 based board where cache is normally enabled, see commit c02712a74849 ("arm: mach-k3: Enable dcache in SPL").

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
