### PR TITLE
arm: add invalidate_dcache_all() to just after disable cache

### DIFF
--- a/arch/arm/lib/cache-cp15.c
+++ b/arch/arm/lib/cache-cp15.c
@@ -254,7 +254,15 @@ static void cache_disable(uint32_t cache_bit)
 	if (cache_bit == CR_C)
 #endif
 		flush_dcache_all();
+
 	set_cr(reg & ~cache_bit);
+
+#ifdef CONFIG_SYS_ARM_MMU
+	if (cache_bit == (CR_C | CR_M))
+#elif defined(CONFIG_SYS_ARM_MPU)
+	if (cache_bit == CR_C)
+#endif
+		invalidate_dcache_all();
 }
 #endif
 


### PR DESCRIPTION
On Cortex-R5 flushing and disabling cache is not enough to avoid cache and memory incoherence.

In particular, when the cache is enabled after a disable, and if there are entry in the cache the value from the cache is used instead of the value from the memory. This, in particular, lead to stack corruption if the stack is in a cached area.

The commit 44df5e8d30a2 ("arm: move flush_dcache_all() to just before disable cache") already states that following a cache disable an invalidate is expected to be done but without coping with cache enable. So just add it explicitly.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
