### PR TITLE
xhci: Add soft retry mechanism for control transaction

### DIFF
--- a/drivers/usb/host/xhci-ring.c
+++ b/drivers/usb/host/xhci-ring.c
@@ -580,6 +580,9 @@ static void record_transfer_result(struct usb_device *udev,
 	case COMP_SHORT_TX:
 		udev->status = 0;
 		break;
+	case COMP_TX_ERR:
+		udev->status = USB_ST_CRC_ERR;
+		break;
 	case COMP_STALL:
 		udev->status = USB_ST_STALLED;
 		break;
@@ -978,6 +981,10 @@ int xhci_ctrl_tx(struct usb_device *udev, unsigned long pipe,
 	if (udev->status == USB_ST_STALLED) {
 		reset_ep(udev, ep_index);
 		return -EPIPE;
+	}
+	if (udev->status == USB_ST_CRC_ERR ) {
+		reset_ep(udev, ep_index);
+		return -EAGAIN;
 	}
 
 	/* Invalidate buffer to make it available to usb-core */

--- a/include/usb/xhci.h
+++ b/include/usb/xhci.h
@@ -33,6 +33,8 @@
 /* Section 5.3.3 - MaxPorts */
 #define MAX_HC_PORTS            255
 
+#define SOFT_RESET_ATTEMPTS	3
+
 /* Up to 16 ms to halt an HC */
 #define XHCI_MAX_HALT_USEC	(16*1000)
 


### PR DESCRIPTION
A Soft Retry may effectively be used to recover from a USB Transaction Error that was due to a temporary error condition.

Software shall limit the number of unsuccessful Soft Retry attempts to prevent an infinite loop.

For more details on Soft retry see xhci specs  4.6.8.1

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
