### PR TITLE
efi: bootefi: Remove non-compliant DT nodes and properties

### DIFF
--- a/cmd/bootefi.c
+++ b/cmd/bootefi.c
@@ -318,6 +318,7 @@ efi_status_t efi_install_fdt(void *fdt)
 	efi_carve_out_dt_rsv(fdt);
 
 	efi_try_purge_kaslr_seed(fdt);
+	efi_dt_nodes_props_purge(fdt);
 
 	if (CONFIG_IS_ENABLED(EFI_TCG2_PROTOCOL_MEASURE_DTB)) {
 		ret = efi_tcg2_measure_dtb(fdt);

--- a/include/efi_loader.h
+++ b/include/efi_loader.h
@@ -547,6 +547,25 @@ efi_status_t EFIAPI efi_convert_pointer(efi_uintn_t debug_disposition,
 void efi_carve_out_dt_rsv(void *fdt);
 /* Purge unused kaslr-seed */
 void efi_try_purge_kaslr_seed(void *fdt);
+
+/**
+ * efi_dt_nodes_props_purge() - Remove non upstreamed nodes and properties
+ *				from the DT
+ * @fdt: Pointer to the FDT
+ *
+ * Iterate through an array of DT nodes and properties, and remove them
+ * from the device-tree before the DT gets handed over to the kernel.
+ * These are nodes and properties which do not have upstream bindings
+ * and need to be purged before being handed over to the kernel.
+ *
+ * If both the node and property are specified, delete the property. If
+ * only the node is specified, delete the entire node, including it's
+ * subnodes, if any.
+ *
+ * Return: None
+ */
+void efi_dt_nodes_props_purge(void *fdt);
+
 /* Called by bootefi to make console interface available */
 efi_status_t efi_console_register(void);
 /* Called by efi_init_obj_list() to proble all block devices */


### PR DESCRIPTION
Purge certain devicetree nodes and properties before the DT gets passed on to the kernel as EFI configuration table. This is used for removing any non-compliant nodes/properties from the DT before getting passed onto the kernel.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
