### PR TITLE
pylibfdt: Fix "invalid escape sequence '\w'" in setup.py

### DIFF
--- a/scripts/dtc/pylibfdt/setup.py
+++ b/scripts/dtc/pylibfdt/setup.py
@@ -37,7 +37,7 @@ with open(os.path.join(srcdir, "../README"), "r") as fh:
     long_description = fh.read()
 
 # Decodes a Makefile assignment line into key and value (and plus for +=)
-RE_KEY_VALUE = re.compile('(?P<key>\w+) *(?P<plus>[+])?= *(?P<value>.*)$')
+RE_KEY_VALUE = re.compile(r'(?P<key>\w+) *(?P<plus>[+])?= *(?P<value>.*)$')
 
 def get_top_builddir():
     if '--top-builddir' in sys.argv:


### PR DESCRIPTION
Once u-boot's build system invokes

python3 scripts/dtc/pylibfdt/setup.py --quiet build_ext --inplace

it may fail with

scripts/dtc/pylibfdt/setup.py:40: SyntaxWarning: invalid escape sequence '\w'
  RE_KEY_VALUE = re.compile('(?P<key>\w+) *(?P<plus>[+])?= *(?P<value>.*)$')

depending on the used Python version.

Explicitly mark the regex string as raw string to avoid the warning.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
