### PR TITLE
net: am65-cpsw: cpsw_mdio: Switch to proper DM_MDIO

### DIFF
--- a/drivers/net/ti/Kconfig
+++ b/drivers/net/ti/Kconfig
@@ -45,7 +45,15 @@ config TI_AM65_CPSW_NUSS
 	imply MISC_INIT_R
 	imply MISC
 	imply SYSCON
+	imply MDIO_TI_CPSW
 	select PHYLIB
 	help
 	  This driver supports TI K3 MCU CPSW Nuss Ethernet controller
 	  in Texas Instruments K3 AM65x SoCs.
+
+config MDIO_TI_CPSW
+	bool "TI CPSW MDIO interface support"
+	depends on DM_MDIO
+	help
+	  This driver supports the TI CPSW MDIO interface found in various
+	  TI SoCs.

--- a/drivers/net/ti/Makefile
+++ b/drivers/net/ti/Makefile
@@ -5,4 +5,5 @@
 obj-$(CONFIG_DRIVER_TI_CPSW) += cpsw.o cpsw-common.o cpsw_mdio.o
 obj-$(CONFIG_DRIVER_TI_EMAC) += davinci_emac.o
 obj-$(CONFIG_DRIVER_TI_KEYSTONE_NET) += keystone_net.o cpsw_mdio.o
-obj-$(CONFIG_TI_AM65_CPSW_NUSS) += am65-cpsw-nuss.o cpsw_mdio.o
+obj-$(CONFIG_TI_AM65_CPSW_NUSS) += am65-cpsw-nuss.o
+obj-$(CONFIG_MDIO_TI_CPSW) += cpsw_mdio.o

--- a/drivers/net/ti/cpsw_mdio.h
+++ b/drivers/net/ti/cpsw_mdio.h
@@ -10,9 +10,11 @@
 
 struct cpsw_mdio;
 
+#if !defined(CONFIG_MDIO_TI_CPSW)
 struct mii_dev *cpsw_mdio_init(const char *name, phys_addr_t mdio_base,
 			       u32 bus_freq, int fck_freq, bool manual_mode);
 void cpsw_mdio_free(struct mii_dev *bus);
 u32 cpsw_mdio_get_alive(struct mii_dev *bus);
+#endif /* CONFIG_MDIO_TI_CPSW */
 
 #endif /* CPSW_MDIO_H_ */


### PR DESCRIPTION
** Only for CI testing **

If DM_MDIO is enabled then build the cpsw_mdio driver with proper DM support.

Clean up MDIO custom handling in am65-cpsw and use dm_eth_phy_connect() to get the PHY.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
