### PR TITLE
mediatek: cumulative trivial fix for OF_UPSTREAM support

### DIFF
--- a/common/cyclic.c
+++ b/common/cyclic.c
@@ -9,6 +9,7 @@
  */
 
 #include <cyclic.h>
+#include <env.h>
 #include <log.h>
 #include <malloc.h>
 #include <time.h>
@@ -19,6 +20,17 @@
 DECLARE_GLOBAL_DATA_PTR;
 
 void hw_watchdog_reset(void);
+
+static unsigned int max_cpu_time = CONFIG_CYCLIC_MAX_CPU_TIME_US;
+
+static int on_cyclic_max_cpu_time(const char *name, const char *value,
+				  enum env_op op, int flags)
+{
+	if (op != env_op_delete)
+		max_cpu_time = dectoul(value, NULL);
+	return 0;
+}
+U_BOOT_ENV_CALLBACK(cyclic_max_cpu_time, on_cyclic_max_cpu_time);
 
 struct hlist_head *cyclic_get_list(void)
 {
@@ -70,11 +82,10 @@ void cyclic_run(void)
 			cyclic->cpu_time_us += cpu_time;
 
 			/* Check if cpu-time exceeds max allowed time */
-			if ((cpu_time > CONFIG_CYCLIC_MAX_CPU_TIME_US) &&
+			if ((cpu_time > max_cpu_time) &&
 			    (!cyclic->already_warned)) {
 				pr_err("cyclic function %s took too long: %lldus vs %dus max\n",
-				       cyclic->name, cpu_time,
-				       CONFIG_CYCLIC_MAX_CPU_TIME_US);
+				       cyclic->name, cpu_time, max_cpu_time);
 
 				/*
 				 * Don't disable this function, just warn once

--- a/drivers/clk/mediatek/clk-mt7981.c
+++ b/drivers/clk/mediatek/clk-mt7981.c
@@ -543,6 +543,7 @@ static const struct mtk_clk_tree mt7981_infracfg_clk_tree = {
 
 static const struct udevice_id mt7981_fixed_pll_compat[] = {
 	{ .compatible = "mediatek,mt7981-fixed-plls" },
+	{ .compatible = "mediatek,mt7981-apmixedsys" },
 	{}
 };
 

--- a/drivers/clk/mediatek/clk-mt7986.c
+++ b/drivers/clk/mediatek/clk-mt7986.c
@@ -533,6 +533,7 @@ static const struct mtk_clk_tree mt7986_infracfg_clk_tree = {
 
 static const struct udevice_id mt7986_fixed_pll_compat[] = {
 	{ .compatible = "mediatek,mt7986-fixed-plls" },
+	{ .compatible = "mediatek,mt7986-apmixedsys" },
 	{}
 };
 

--- a/drivers/clk/mediatek/clk-mt7988.c
+++ b/drivers/clk/mediatek/clk-mt7988.c
@@ -833,6 +833,7 @@ static const struct mtk_clk_tree mt7988_infracfg_clk_tree = {
 
 static const struct udevice_id mt7988_fixed_pll_compat[] = {
 	{ .compatible = "mediatek,mt7988-fixed-plls" },
+	{ .compatible = "mediatek,mt7988-apmixedsys" },
 	{}
 };
 

--- a/drivers/net/mtk_eth.c
+++ b/drivers/net/mtk_eth.c
@@ -1964,7 +1964,9 @@ static int mtk_eth_of_to_plat(struct udevice *dev)
 			return -ENODEV;
 		}
 
-		priv->pn_swap = ofnode_read_bool(args.node, "pn_swap");
+		/* Upstream linux use mediatek,pnswap instead of pn_swap */
+		priv->pn_swap = ofnode_read_bool(args.node, "pn_swap") ||
+				ofnode_read_bool(args.node, "mediatek,pnswap");
 	} else if (priv->phy_interface == PHY_INTERFACE_MODE_USXGMII) {
 		/* get corresponding usxgmii phandle */
 		ret = dev_read_phandle_with_args(dev, "mediatek,usxgmiisys",

--- a/drivers/pci/Kconfig
+++ b/drivers/pci/Kconfig
@@ -350,6 +350,13 @@ config PCIE_MEDIATEK
 	  Say Y here if you want to enable Gen2 PCIe controller,
 	  which could be found on MT7623 SoC family.
 
+config PCIE_MEDIATEK_GEN3
+	bool "MediaTek PCIe Gen3 controller"
+	depends on ARCH_MEDIATEK
+	help
+	  Say Y here if you want to enable Gen3 PCIe controller,
+	  which could be found on the Mediatek Filogic SoC family.
+
 config PCIE_DW_MESON
 	bool "Amlogic Meson DesignWare based PCIe controller"
 	depends on ARCH_MESON

--- a/drivers/pci/Makefile
+++ b/drivers/pci/Makefile
@@ -42,6 +42,7 @@ obj-$(CONFIG_PCIE_INTEL_FPGA) += pcie_intel_fpga.o
 obj-$(CONFIG_PCIE_DW_COMMON) += pcie_dw_common.o
 obj-$(CONFIG_PCI_KEYSTONE) += pcie_dw_ti.o
 obj-$(CONFIG_PCIE_MEDIATEK) += pcie_mediatek.o
+obj-$(CONFIG_PCIE_MEDIATEK_GEN3) += pcie_mediatek_gen3.o
 obj-$(CONFIG_PCIE_ROCKCHIP) += pcie_rockchip.o
 obj-$(CONFIG_PCIE_DW_ROCKCHIP) += pcie_dw_rockchip.o
 obj-$(CONFIG_PCIE_DW_MESON) += pcie_dw_meson.o

--- a/drivers/pci/pcie_mediatek_gen3.c
+++ b/drivers/pci/pcie_mediatek_gen3.c
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * MediaTek PCIe host controller driver.
+ *
+ * Copyright (c) 2023 John Crispin <john@phrozen.org>
+ * Driver is based on u-boot gen1/2 and upstream linux gen3 code
+ */
+
+#include <clk.h>
+#include <dm.h>
+#include <generic-phy.h>
+#include <log.h>
+#include <malloc.h>
+#include <pci.h>
+#include <reset.h>
+#include <asm/io.h>
+#include <dm/device_compat.h>
+#include <dm/devres.h>
+#include <linux/bitops.h>
+#include <linux/iopoll.h>
+#include <linux/list.h>
+#include "pci_internal.h"
+
+/* PCIe shared registers */
+#define PCIE_CFG_ADDR			0x20
+#define PCIE_CFG_DATA			0x24
+
+#define PCIE_SETTING_REG		0x80
+
+#define PCIE_PCI_IDS_1			0x9c
+#define PCIE_RC_MODE			BIT(0)
+#define PCI_CLASS(class)		((class) << 8)
+
+#define PCIE_CFGNUM_REG			0x140
+#define PCIE_CFG_DEVFN(devfn)		((devfn) & GENMASK(7, 0))
+#define PCIE_CFG_BUS(bus)		(((bus) << 8) & GENMASK(15, 8))
+#define PCIE_CFG_BYTE_EN(bytes)		(((bytes) << 16) & GENMASK(19, 16))
+#define PCIE_CFG_FORCE_BYTE_EN		BIT(20)
+#define PCIE_CFG_OFFSET_ADDR		0x1000
+#define PCIE_CFG_HEADER(bus, devfn)	(PCIE_CFG_BUS(bus) | PCIE_CFG_DEVFN(devfn))
+
+#define PCIE_RST_CTRL_REG		0x148
+#define PCIE_MAC_RSTB			BIT(0)
+#define PCIE_PHY_RSTB			BIT(1)
+#define PCIE_BRG_RSTB			BIT(2)
+#define PCIE_PE_RSTB			BIT(3)
+
+#define PCIE_LINK_STATUS_REG		0x154
+#define PCIE_PORT_LINKUP		BIT(8)
+
+#define PCIE_INT_ENABLE_REG		0x180
+
+#define PCIE_MISC_CTRL_REG		0x348
+#define PCIE_DISABLE_DVFSRC_VLT_REQ	BIT(1)
+
+#define PCIE_TRANS_TABLE_BASE_REG       0x800
+#define PCIE_ATR_SRC_ADDR_MSB_OFFSET    0x4
+#define PCIE_ATR_TRSL_ADDR_LSB_OFFSET   0x8
+#define PCIE_ATR_TRSL_ADDR_MSB_OFFSET   0xc
+#define PCIE_ATR_TRSL_PARAM_OFFSET      0x10
+#define PCIE_ATR_TLB_SET_OFFSET         0x20
+
+#define PCIE_MAX_TRANS_TABLES           8
+#define PCIE_ATR_EN                     BIT(0)
+#define PCIE_ATR_SIZE(size) \
+	(((((size) - 1) << 1) & GENMASK(6, 1)) | PCIE_ATR_EN)
+#define PCIE_ATR_ID(id)                 ((id) & GENMASK(3, 0))
+#define PCIE_ATR_TYPE_MEM               PCIE_ATR_ID(0)
+#define PCIE_ATR_TYPE_IO                PCIE_ATR_ID(1)
+#define PCIE_ATR_TLP_TYPE(type)         (((type) << 16) & GENMASK(18, 16))
+#define PCIE_ATR_TLP_TYPE_MEM           PCIE_ATR_TLP_TYPE(0)
+#define PCIE_ATR_TLP_TYPE_IO            PCIE_ATR_TLP_TYPE(2)
+
+struct mtk_pcie {
+	void __iomem *base;
+	void *priv;
+	struct clk pl_250m_ck;
+	struct clk tl_26m_ck;
+	struct clk peri_26m_ck;
+	struct clk top_133m_ck;
+	struct reset_ctl reset_phy;
+	struct reset_ctl reset_mac;
+	struct phy phy;
+};
+
+static void mtk_pcie_config_tlp_header(const struct udevice *bus,
+				       pci_dev_t devfn,
+				       int where, int size)
+{
+	struct mtk_pcie *pcie = dev_get_priv(bus);
+	int bytes;
+	u32 val;
+
+	size = 1 << size;
+	bytes = (GENMASK(size - 1, 0) & 0xf) << (where & 0x3);
+
+	val = PCIE_CFG_FORCE_BYTE_EN | PCIE_CFG_BYTE_EN(bytes) |
+	      PCIE_CFG_HEADER(PCI_BUS(devfn), (devfn >> 8));
+
+	writel(val, pcie->base + PCIE_CFGNUM_REG);
+}
+
+static int mtk_pcie_config_address(const struct udevice *udev, pci_dev_t bdf,
+				   uint offset, void **paddress)
+{
+	struct mtk_pcie *pcie = dev_get_priv(udev);
+
+	*paddress = pcie->base + PCIE_CFG_OFFSET_ADDR + offset;
+
+	return 0;
+}
+
+static int mtk_pcie_read_config(const struct udevice *bus, pci_dev_t bdf,
+				uint offset, ulong *valuep,
+				enum pci_size_t size)
+{
+	int ret;
+
+	mtk_pcie_config_tlp_header(bus, bdf, offset, size);
+	ret = pci_generic_mmap_read_config(bus, mtk_pcie_config_address,
+					   bdf, offset, valuep, size);
+	return ret;
+}
+
+static int mtk_pcie_write_config(struct udevice *bus, pci_dev_t bdf,
+				 uint offset, ulong value,
+				 enum pci_size_t size)
+{
+	mtk_pcie_config_tlp_header(bus, bdf, offset, size);
+
+	switch (size) {
+	case PCI_SIZE_8:
+	case PCI_SIZE_16:
+		value <<= (offset & 0x3) * 8;
+	case PCI_SIZE_32:
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return pci_generic_mmap_write_config(bus, mtk_pcie_config_address,
+					     bdf, (offset & ~0x3), value, PCI_SIZE_32);
+}
+
+static const struct dm_pci_ops mtk_pcie_ops = {
+	.read_config	= mtk_pcie_read_config,
+	.write_config	= mtk_pcie_write_config,
+};
+
+static int mtk_pcie_set_trans_table(struct udevice *dev, struct mtk_pcie *pcie,
+				    u64 cpu_addr, u64 pci_addr, u64 size,
+				    unsigned long type, int num)
+{
+	void __iomem *table;
+	u32 val;
+
+	if (num >= PCIE_MAX_TRANS_TABLES) {
+		dev_err(dev, "not enough translate table for addr: %#llx, limited to [%d]\n",
+			(unsigned long long)cpu_addr, PCIE_MAX_TRANS_TABLES);
+		return -ENODEV;
+	}
+
+	dev_dbg(dev, "set trans table %d: %#llx %#llx, %#llx\n", num, cpu_addr,
+		pci_addr, size);
+	table = pcie->base + PCIE_TRANS_TABLE_BASE_REG +
+		num * PCIE_ATR_TLB_SET_OFFSET;
+
+	writel(lower_32_bits(cpu_addr) | PCIE_ATR_SIZE(fls(size) - 1), table);
+	writel(upper_32_bits(cpu_addr), table + PCIE_ATR_SRC_ADDR_MSB_OFFSET);
+	writel(lower_32_bits(pci_addr), table + PCIE_ATR_TRSL_ADDR_LSB_OFFSET);
+	writel(upper_32_bits(pci_addr), table + PCIE_ATR_TRSL_ADDR_MSB_OFFSET);
+
+	if (type == PCI_REGION_IO)
+		val = PCIE_ATR_TYPE_IO | PCIE_ATR_TLP_TYPE_IO;
+	else
+		val = PCIE_ATR_TYPE_MEM | PCIE_ATR_TLP_TYPE_MEM;
+	writel(val, table + PCIE_ATR_TRSL_PARAM_OFFSET);
+
+	return 0;
+}
+
+static int mtk_pcie_startup_port(struct udevice *dev)
+{
+	struct mtk_pcie *pcie = dev_get_priv(dev);
+	struct udevice *ctlr = pci_get_controller(dev);
+	struct pci_controller *hose = dev_get_uclass_priv(ctlr);
+	u32 val;
+	int i, err;
+
+	/* Set as RC mode */
+	val = readl(pcie->base + PCIE_SETTING_REG);
+	val |= PCIE_RC_MODE;
+	writel(val, pcie->base + PCIE_SETTING_REG);
+
+	/* setup RC BARs */
+	writel(PCI_BASE_ADDRESS_MEM_TYPE_64,
+	       pcie->base + PCI_BASE_ADDRESS_0);
+	writel(0x0, pcie->base + PCI_BASE_ADDRESS_1);
+
+	/* setup interrupt pins */
+	clrsetbits_le32(pcie->base + PCI_INTERRUPT_LINE,
+			0xff00, 0x100);
+
+	/* setup bus numbers */
+	clrsetbits_le32(pcie->base + PCI_PRIMARY_BUS,
+			0xffffff, 0x00ff0100);
+
+	/* setup command register */
+	clrsetbits_le32(pcie->base + PCI_PRIMARY_BUS,
+			0xffff,
+			PCI_COMMAND_IO | PCI_COMMAND_MEMORY |
+			PCI_COMMAND_MASTER | PCI_COMMAND_SERR);
+
+	/* Set class code */
+	val = readl(pcie->base + PCIE_PCI_IDS_1);
+	val &= ~GENMASK(31, 8);
+	val |= PCI_CLASS(PCI_CLASS_BRIDGE_PCI << 8);
+	writel(val, pcie->base + PCIE_PCI_IDS_1);
+
+	/* Mask all INTx interrupts */
+	val = readl(pcie->base + PCIE_INT_ENABLE_REG);
+	val &= ~0xFF000000;
+	writel(val, pcie->base + PCIE_INT_ENABLE_REG);
+
+	/* Disable DVFSRC voltage request */
+	val = readl(pcie->base + PCIE_MISC_CTRL_REG);
+	val |= PCIE_DISABLE_DVFSRC_VLT_REQ;
+	writel(val, pcie->base + PCIE_MISC_CTRL_REG);
+
+	/* Assert all reset signals */
+	val = readl(pcie->base + PCIE_RST_CTRL_REG);
+	val |= PCIE_MAC_RSTB | PCIE_PHY_RSTB | PCIE_BRG_RSTB | PCIE_PE_RSTB;
+	writel(val, pcie->base + PCIE_RST_CTRL_REG);
+
+	/*
+	 * Described in PCIe CEM specification sections 2.2 (PERST# Signal)
+	 * and 2.2.1 (Initial Power-Up (G3 to S0)).
+	 * The deassertion of PERST# should be delayed 100ms (TPVPERL)
+	 * for the power and clock to become stable.
+	 */
+	mdelay(100);
+
+	/* De-assert reset signals */
+	val &= ~(PCIE_MAC_RSTB | PCIE_PHY_RSTB | PCIE_BRG_RSTB);
+	writel(val, pcie->base + PCIE_RST_CTRL_REG);
+
+	mdelay(100);
+
+	/* De-assert PERST# signals */
+	val &= ~(PCIE_PE_RSTB);
+	writel(val, pcie->base + PCIE_RST_CTRL_REG);
+
+	/* 100ms timeout value should be enough for Gen1/2 training */
+	err = readl_poll_timeout(pcie->base + PCIE_LINK_STATUS_REG, val,
+				 !!(val & PCIE_PORT_LINKUP),
+				 100 * 1000);
+	if (err) {
+		dev_dbg(dev, "no card detected\n");
+		return -ETIMEDOUT;
+	}
+	dev_dbg(dev, "detected a card\n");
+
+	for (i = 0; i < hose->region_count; i++) {
+		struct pci_region *reg = &hose->regions[i];
+
+		if (reg->flags != PCI_REGION_MEM)
+			continue;
+
+		mtk_pcie_set_trans_table(dev, pcie, reg->bus_start, reg->phys_start,
+					 reg->size, reg->flags, 0);
+	}
+
+	return 0;
+}
+
+static int mtk_pcie_power_on(struct udevice *dev)
+{
+	struct mtk_pcie *pcie = dev_get_priv(dev);
+	int err;
+
+	pcie->base = dev_remap_addr_name(dev, "pcie-mac");
+	if (!pcie->base)
+		return -ENOENT;
+
+	pcie->priv = dev;
+
+	err = generic_phy_get_by_name(dev, "pcie-phy", &pcie->phy);
+	if (err)
+		return err;
+
+	/*
+	 * Upstream linux kernel devine these clock without clock-names
+	 * and use clk bulk API to enable them all.
+	 */
+	err = clk_get_by_index(dev, 0, &pcie->pl_250m_ck);
+	if (err)
+		return err;
+
+	err = clk_get_by_index(dev, 1, &pcie->tl_26m_ck);
+	if (err)
+		return err;
+
+	err = clk_get_by_index(dev, 2, &pcie->peri_26m_ck);
+	if (err)
+		return err;
+
+	err = clk_get_by_index(dev, 3, &pcie->top_133m_ck);
+	if (err)
+		return err;
+
+	err = generic_phy_init(&pcie->phy);
+	if (err)
+		return err;
+
+	err = generic_phy_power_on(&pcie->phy);
+	if (err)
+		goto err_phy_on;
+
+	err = clk_enable(&pcie->pl_250m_ck);
+	if (err)
+		goto err_clk_pl_250m;
+
+	err = clk_enable(&pcie->tl_26m_ck);
+	if (err)
+		goto err_clk_tl_26m;
+
+	err = clk_enable(&pcie->peri_26m_ck);
+	if (err)
+		goto err_clk_peri_26m;
+
+	err = clk_enable(&pcie->top_133m_ck);
+	if (err)
+		goto err_clk_top_133m;
+
+	err = mtk_pcie_startup_port(dev);
+	if (err)
+		goto err_startup;
+
+	return 0;
+
+err_startup:
+err_clk_top_133m:
+	clk_disable(&pcie->top_133m_ck);
+err_clk_peri_26m:
+	clk_disable(&pcie->peri_26m_ck);
+err_clk_tl_26m:
+	clk_disable(&pcie->tl_26m_ck);
+err_clk_pl_250m:
+	clk_disable(&pcie->pl_250m_ck);
+err_phy_on:
+	generic_phy_exit(&pcie->phy);
+
+	return err;
+}
+
+static int mtk_pcie_probe(struct udevice *dev)
+{
+	struct mtk_pcie *pcie = dev_get_priv(dev);
+	int err;
+
+	pcie->priv = dev;
+
+	err = mtk_pcie_power_on(dev);
+	if (err)
+		return err;
+
+	return 0;
+}
+
+static const struct udevice_id mtk_pcie_ids[] = {
+	{ .compatible = "mediatek,mt8192-pcie" },
+	{ }
+};
+
+U_BOOT_DRIVER(pcie_mediatek_gen3) = {
+	.name		= "pcie_mediatek_gen3",
+	.id		= UCLASS_PCI,
+	.of_match	= mtk_pcie_ids,
+	.ops		= &mtk_pcie_ops,
+	.probe		= mtk_pcie_probe,
+	.priv_auto	= sizeof(struct mtk_pcie),
+};

--- a/drivers/phy/Kconfig
+++ b/drivers/phy/Kconfig
@@ -263,6 +263,8 @@ config PHY_MTK_TPHY
 	bool "MediaTek T-PHY Driver"
 	depends on PHY
 	depends on ARCH_MEDIATEK || SOC_MT7621
+	select REGMAP
+	select SYSCON
 	help
 	  MediaTek T-PHY driver supports usb2.0, usb3.0 ports, PCIe and
 	  SATA, and meanwhile supports two version T-PHY which have

--- a/drivers/pinctrl/mediatek/pinctrl-mt7981.c
+++ b/drivers/pinctrl/mediatek/pinctrl-mt7981.c
@@ -1050,4 +1050,5 @@ U_BOOT_DRIVER(mt7981_pinctrl) = {
 	.ops = &mtk_pinctrl_ops,
 	.probe = mtk_pinctrl_mt7981_probe,
 	.priv_auto = sizeof(struct mtk_pinctrl_priv),
+	.flags = DM_FLAG_PRE_RELOC,
 };

--- a/drivers/pinctrl/mediatek/pinctrl-mtk-common.c
+++ b/drivers/pinctrl/mediatek/pinctrl-mtk-common.c
@@ -761,6 +761,15 @@ static int mtk_gpiochip_register(struct udevice *parent)
 	if (!drv)
 		return -ENOENT;
 
+	/*
+	 * Support upstream linux DTSI that define gpio-controller
+	 * in the root node (instead of a dedicated subnode)
+	 */
+	if (dev_read_bool(parent, "gpio-controller")) {
+		node = dev_ofnode(parent);
+		goto bind;
+	}
+
 	ret = -ENOENT;
 	dev_for_each_subnode(node, parent)
 		if (ofnode_read_bool(node, "gpio-controller")) {
@@ -771,6 +780,7 @@ static int mtk_gpiochip_register(struct udevice *parent)
 	if (ret)
 		return ret;
 
+bind:
 	ret = device_bind_with_driver_data(parent, &mtk_gpio_driver,
 					   "mediatek_gpio", 0, node,
 					   &dev);

--- a/drivers/serial/serial_mtk.c
+++ b/drivers/serial/serial_mtk.c
@@ -76,6 +76,7 @@ struct mtk_serial_regs {
  *				driver
  * @regs:			Register base of the serial port
  * @clk:			The baud clock device
+ * @clk_bus:			The bus clock device
  * @fixed_clk_rate:		Fallback fixed baud clock rate if baud clock
  *				device is not specified
  * @force_highspeed:		Force using high-speed mode
@@ -83,6 +84,7 @@ struct mtk_serial_regs {
 struct mtk_serial_priv {
 	struct mtk_serial_regs __iomem *regs;
 	struct clk clk;
+	struct clk clk_bus;
 	u32 fixed_clk_rate;
 	bool force_highspeed;
 };
@@ -220,6 +222,10 @@ static int mtk_serial_probe(struct udevice *dev)
 	writel(UART_MCRVAL, &priv->regs->mcr);
 	writel(UART_FCRVAL, &priv->regs->fcr);
 
+	clk_enable(&priv->clk);
+	if (priv->clk_bus.dev)
+		clk_enable(&priv->clk_bus);
+
 	return 0;
 }
 
@@ -249,6 +255,8 @@ static int mtk_serial_of_to_plat(struct udevice *dev)
 			return -EINVAL;
 		}
 	}
+
+	clk_get_by_name(dev, "bus", &priv->clk_bus);
 
 	priv->force_highspeed = dev_read_bool(dev, "mediatek,force-highspeed");
 

--- a/include/env_callback.h
+++ b/include/env_callback.h
@@ -69,6 +69,12 @@
 #define BOOTSTD_CALLBACK
 #endif
 
+#ifdef CONFIG_CYCLIC
+#define CYCLIC_CALLBACK ENV_DOT_ESCAPE ".cyclic_max_cpu_time:cyclic_max_cpu_time,"
+#else
+#define CYCLIC_CALLBACK
+#endif
+
 /*
  * This list of callback bindings is static, but may be overridden by defining
  * a new association in the ".callbacks" environment variable.
@@ -83,6 +89,7 @@
 	SILENT_CALLBACK \
 	"stdin:console,stdout:console,stderr:console," \
 	"serial#:serialno," \
+	CYCLIC_CALLBACK \
 	CFG_ENV_CALLBACK_LIST_STATIC
 
 #ifndef CONFIG_SPL_BUILD

--- a/test/py/u_boot_console_base.py
+++ b/test/py/u_boot_console_base.py
@@ -205,6 +205,7 @@ class ConsoleBase(object):
                     continue
                 raise Exception('Bad pattern found on console: ' +
                                 self.bad_pattern_ids[m - 2])
+            self.run_command("env set .cyclic_max_cpu_time 100000")
 
         except Exception as ex:
             self.log.error(str(ex))


### PR DESCRIPTION
This is an initial series that have all the initial trivial
fixes required for usage of OF_UPSTREAM for the mediatek SoC

This also contains the pcie-gen3 driver and the required tphy
support driver to make it work.

Subsequent series will follow with conversion of the mtk-clk
to permit usage of OF_UPSTREAM and upstream clk ID.

MT7981, MT7986 and MT7988 migration to upstream clock ID
is complete and working on MT7623.