### PR TITLE
mx23: fix VDDM drop and boot instabilities

### DIFF
--- a/arch/arm/cpu/arm926ejs/mxs/spl_mem_init.c
+++ b/arch/arm/cpu/arm926ejs/mxs/spl_mem_init.c
@@ -275,8 +275,6 @@ static void mx23_mem_init(void)
 	 */
 	mxs_reset_block((struct mxs_register_32 *)MXS_EMI_BASE);
 
-	mx23_mem_setup_vddmem();
-
 	/*
 	 * Configure the DRAM registers
 	 */
@@ -343,6 +341,12 @@ static void mx28_mem_init(void)
 void mxs_mem_init(void)
 {
 	early_delay(11000);
+
+#if defined(CONFIG_MX23)
+	//disable memory current limiter (before accessing memory, see datasheet page 1307 - ENABLE_ILIMIT)
+	//otherwise the VDDM will drop to 2V and can cause reboot loops
+	mx23_mem_setup_vddmem();
+#endif
 
 	mxs_mem_init_clock();
 


### PR DESCRIPTION
disabling the current limit too late, will cause the VDDM to drop to ~2V @ boot and causes reboot loops on 2%-5% of the cpu's with production date >= 2017 when the cpu's are cold.

VDDM drop issue (without patch):
![imx23_uboot_VDDM_drop_issue](https://github.com/u-boot/u-boot/assets/6324597/356663cb-2bb8-427d-ac94-d576e28e81d0)

VDDM drop issue fixed (with patch):
![imx23_uboot_VDDM_drop_issue_solved](https://github.com/u-boot/u-boot/assets/6324597/df94bf1d-a33e-4c78-a595-3a5efa5c0182)

CPU from 2015, boot's when it's cold without patch:
![IMX23_2015_batch](https://github.com/u-boot/u-boot/assets/6324597/b6483c92-72a2-40fe-89f9-9665251f056f)

CPU from 2019, sometimes bootloop's when it's cold without patch:
![IMX23_2019_batch](https://github.com/u-boot/u-boot/assets/6324597/3365c3fc-c90b-4337-a313-a9007a0e5ae7)


Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.