### PR TITLE
[CI TEST] led: update LED boot/activity to reference phandle node instead of label

### DIFF
--- a/arch/sandbox/dts/other.dts
+++ b/arch/sandbox/dts/other.dts
@@ -32,6 +32,7 @@
 			<&other_gpio_b 5 GPIO_ACTIVE_HIGH 3 2 1>,
 			<0>, <&other_gpio_a 12>;
 		other-phandle-value = <&other_gpio_c 10>, <0xFFFFFFFF 20>, <&other_gpio_a 30>;
+		other-phandle-nodes = <&other_phandle_node_1>, <&other_phandle_node_2>;
 	};
 
 	other_gpio_a: other-gpio-a {
@@ -44,6 +45,12 @@
 
 	other_gpio_c: other-gpio-c {
 		#gpio-cells = <2>;
+	};
+
+	other_phandle_node_1: other-phandle-node-1 {
+	};
+
+	other_phandle_node_2: other-phandle-node-2 {
 	};
 
 	target: target {

--- a/arch/sandbox/dts/other.dts
+++ b/arch/sandbox/dts/other.dts
@@ -8,13 +8,15 @@
 
 /dts-v1/;
 
+#include <dt-bindings/gpio/gpio.h>
+
 / {
 	compatible = "sandbox-other";
 	#address-cells = <1>;
 	#size-cells = <1>;
 
 	node {
-		target = <&target 3 4>;
+		other-phandle = <&target>;
 
 		subnode {
 			compatible = "sandbox-other2";
@@ -25,9 +27,27 @@
 		};
 	};
 
+	other-a-test {
+		other-test-gpios = <&other_gpio_a 1>, <&other_gpio_a 4>,
+			<&other_gpio_b 5 GPIO_ACTIVE_HIGH 3 2 1>,
+			<0>, <&other_gpio_a 12>;
+		other-phandle-value = <&other_gpio_c 10>, <0xFFFFFFFF 20>, <&other_gpio_a 30>;
+	};
+
+	other_gpio_a: other-gpio-a {
+		#gpio-cells = <1>;
+	};
+
+	other_gpio_b: other-gpio-b {
+		#gpio-cells = <5>;
+	};
+
+	other_gpio_c: other-gpio-c {
+		#gpio-cells = <2>;
+	};
+
 	target: target {
 		compatible = "sandbox-other2";
-		#gpio-cells = <2>;
 		str-prop = "other";
 		reg = <0x8000 0x100>;
 		status = "disabled";

--- a/arch/sandbox/dts/test.dts
+++ b/arch/sandbox/dts/test.dts
@@ -106,6 +106,7 @@
 			testing-bool;
 			testing-int = <123>;
 			testing-str = "testing";
+			testing-phandle = <&phandle_node_1>;
 		};
 	};
 

--- a/arch/sandbox/dts/test.dts
+++ b/arch/sandbox/dts/test.dts
@@ -101,8 +101,8 @@
 			bootscr-ram-offset = /bits/ 64 <0x12345678>;
 			bootscr-flash-offset = /bits/ 64 <0>;
 			bootscr-flash-size = /bits/ 64 <0x2000>;
-			boot-led = "sandbox:green";
-			activity-led = "sandbox:red";
+			boot-led = <&sandbox_led_green>;
+			activity-led = <&sandbox_led_red>;
 			testing-bool;
 			testing-int = <123>;
 			testing-str = "testing";
@@ -988,12 +988,12 @@
 	leds {
 		compatible = "gpio-leds";
 
-		iracibble {
+		sandbox_led_red: iracibble {
 			gpios = <&gpio_a 1 0>;
 			label = "sandbox:red";
 		};
 
-		martinet {
+		sandbox_led_green: martinet {
 			gpios = <&gpio_a 2 0>;
 			label = "sandbox:green";
 		};

--- a/arch/sandbox/dts/test.dts
+++ b/arch/sandbox/dts/test.dts
@@ -296,6 +296,12 @@
 		compatible = "sandbox,dsi-host";
 	};
 
+	phandle_node_1: phandle-node-1 {
+	};
+
+	phandle_node_2: phandle-node-2 {
+	};
+
 	a-test {
 		reg = <0 1>;
 		compatible = "denx,u-boot-fdt-test";
@@ -334,6 +340,7 @@
 		interrupts-extended = <&irq 3 0>;
 		acpi,name = "GHIJ";
 		phandle-value = <&gpio_c 10>, <0xFFFFFFFF 20>, <&gpio_a 30>;
+		phandle-nodes = <&phandle_node_1>, <&phandle_node_2>;
 
 		mux-controls = <&muxcontroller0 0>, <&muxcontroller0 1>,
 			       <&muxcontroller0 2>, <&muxcontroller0 3>,

--- a/drivers/core/ofnode.c
+++ b/drivers/core/ofnode.c
@@ -879,6 +879,64 @@ int ofnode_read_string_list(ofnode node, const char *property,
 	return count;
 }
 
+ofnode ofnode_parse_phandle(ofnode node, const char *phandle_name,
+			    int index)
+{
+	ofnode phandle;
+
+	if (ofnode_is_np(node)) {
+		struct device_node *np;
+
+		np = of_parse_phandle(ofnode_to_np(node), phandle_name,
+				      index);
+		if (!np)
+			return ofnode_null();
+
+		phandle = np_to_ofnode(np);
+	} else {
+		struct fdtdec_phandle_args args;
+
+		if (fdtdec_parse_phandle_with_args(ofnode_to_fdt(node),
+						   ofnode_to_offset(node),
+						   phandle_name, NULL,
+						   0, index, &args))
+			return ofnode_null();
+
+		phandle = offset_to_ofnode(args.node);
+	}
+
+	return phandle;
+}
+
+ofnode oftree_parse_phandle(oftree tree, ofnode node, const char *phandle_name,
+			    int index)
+{
+	ofnode phandle;
+
+	if (ofnode_is_np(node)) {
+		struct device_node *np;
+
+		np = of_root_parse_phandle(tree.np, ofnode_to_np(node),
+					   phandle_name, index);
+		if (!np)
+			return ofnode_null();
+
+		phandle = np_to_ofnode(np);
+	} else {
+		struct fdtdec_phandle_args args;
+
+		if (fdtdec_parse_phandle_with_args(tree.fdt,
+						   ofnode_to_offset(node),
+						   phandle_name, NULL,
+						   0, index, &args))
+			return ofnode_null();
+
+		phandle = noffset_to_ofnode(node, args.node);
+	}
+
+	return phandle;
+}
+
 static void ofnode_from_fdtdec_phandle_args(ofnode node, struct fdtdec_phandle_args *in,
 					    struct ofnode_phandle_args *out)
 {

--- a/drivers/core/ofnode.c
+++ b/drivers/core/ofnode.c
@@ -1871,6 +1871,21 @@ const char *ofnode_options_read_str(const char *prop_name)
 	return ofnode_read_string(uboot, prop_name);
 }
 
+int ofnode_options_get_by_phandle(const char *prop_name, ofnode *nodep)
+{
+	ofnode uboot;
+
+	uboot = ofnode_path("/options/u-boot");
+	if (!ofnode_valid(uboot))
+		return -EINVAL;
+
+	*nodep = ofnode_parse_phandle(uboot, prop_name, 0);
+	if (!ofnode_valid(*nodep))
+		return -EINVAL;
+
+	return 0;
+}
+
 int ofnode_read_bootscript_address(u64 *bootscr_address, u64 *bootscr_offset)
 {
 	int ret;

--- a/include/dm/of_access.h
+++ b/include/dm/of_access.h
@@ -454,6 +454,92 @@ static inline int of_property_count_strings(const struct device_node *np,
 }
 
 /**
+ * of_root_parse_phandle - Resolve a phandle property to a device_node pointer
+ *			   from a root node
+ * @root: Pointer to root device tree node (default root node if NULL)
+ * @np: Pointer to device node holding phandle property
+ * @phandle_name: Name of property holding a phandle value
+ * @index: For properties holding a table of phandles, this is the index into
+ *         the table
+ *
+ * Return:
+ *   the device_node pointer with refcount incremented.  Use
+ *   of_node_put() on it when done.
+ */
+struct device_node *of_root_parse_phandle(struct device_node *root,
+					  const struct device_node *np,
+					  const char *phandle_name, int index);
+
+/**
+ * of_root_parse_phandle_with_args() - Find a node pointed by phandle in a list
+ *				       from a root node
+ *
+ * @root:	pointer to root device tree node (default root node if NULL)
+ * @np:		pointer to a device tree node containing a list
+ * @list_name:	property name that contains a list
+ * @cells_name:	property name that specifies phandles' arguments count
+ * @cells_count: Cell count to use if @cells_name is NULL
+ * @index:	index of a phandle to parse out
+ * @out_args:	optional pointer to output arguments structure (will be filled)
+ * Return:
+ *   0 on success (with @out_args filled out if not NULL), -ENOENT if
+ *   @list_name does not exist, -EINVAL if a phandle was not found,
+ *   @cells_name could not be found, the arguments were truncated or there
+ *   were too many arguments.
+ *
+ * This function is useful to parse lists of phandles and their arguments.
+ * Returns 0 on success and fills out_args, on error returns appropriate
+ * errno value.
+ *
+ * Caller is responsible to call of_node_put() on the returned out_args->np
+ * pointer.
+ *
+ * Example:
+ *
+ * .. code-block::
+ *
+ *   phandle1: node1 {
+ *       #list-cells = <2>;
+ *   };
+ *   phandle2: node2 {
+ *       #list-cells = <1>;
+ *   };
+ *   node3 {
+ *       list = <&phandle1 1 2 &phandle2 3>;
+ *   };
+ *
+ * To get a device_node of the `node2' node you may call this:
+ * of_root_parse_phandle_with_args(node3, "list", "#list-cells", 1, &args);
+ */
+int of_root_parse_phandle_with_args(struct device_node *root,
+				    const struct device_node *np,
+				    const char *list_name, const char *cells_name,
+				    int cells_count, int index,
+				    struct of_phandle_args *out_args);
+
+/**
+ * of_root_count_phandle_with_args() - Count the number of phandle in a list
+ *				       from a root node
+ *
+ * @root:	pointer to root device tree node (default root node if NULL)
+ * @np:		pointer to a device tree node containing a list
+ * @list_name:	property name that contains a list
+ * @cells_name:	property name that specifies phandles' arguments count
+ * @cells_count: Cell count to use if @cells_name is NULL
+ * Return:
+ *   number of phandle found, -ENOENT if @list_name does not exist,
+ *   -EINVAL if a phandle was not found, @cells_name could not be found,
+ *   the arguments were truncated or there were too many arguments.
+ *
+ * Returns number of phandle found on success, on error returns appropriate
+ * errno value.
+ */
+int of_root_count_phandle_with_args(struct device_node *root,
+				    const struct device_node *np,
+				    const char *list_name, const char *cells_name,
+				    int cells_count);
+
+/**
  * of_parse_phandle - Resolve a phandle property to a device_node pointer
  * @np: Pointer to device node holding phandle property
  * @phandle_name: Name of property holding a phandle value

--- a/include/dm/ofnode.h
+++ b/include/dm/ofnode.h
@@ -848,6 +848,18 @@ int ofnode_read_string_list(ofnode node, const char *property,
 			    const char ***listp);
 
 /**
+ * ofnode_parse_phandle() - Resolve a phandle property to an ofnode
+ *
+ * @node: node to check
+ * @phandle_name: Name of property holding a phandle value
+ * @index: For properties holding a table of phandles, this is the index into
+ *         the table
+ * Return: ofnode that the phandle points to or ofnode_null() on error.
+ */
+ofnode ofnode_parse_phandle(ofnode node, const char *phandle_name,
+			    int index);
+
+/**
  * ofnode_parse_phandle_with_args() - Find a node pointed by phandle in a list
  *
  * This function is useful to parse lists of phandles and their arguments.
@@ -908,6 +920,20 @@ int ofnode_parse_phandle_with_args(ofnode node, const char *list_name,
  */
 int ofnode_count_phandle_with_args(ofnode node, const char *list_name,
 				   const char *cells_name, int cell_count);
+
+/**
+ * oftree_parse_phandle() - Resolve a phandle property to an ofnode
+ *			    from a root node
+ *
+ * @tree: device tree to use
+ * @node: node to check
+ * @phandle_name: Name of property holding a phandle value
+ * @index: For properties holding a table of phandles, this is the index into
+ *         the table
+ * Return: ofnode that the phandle points to or ofnode_null() on error.
+ */
+ofnode oftree_parse_phandle(oftree tree, ofnode node, const char *phandle_name,
+			    int index);
 
 /**
  * oftree_parse_phandle_with_args() - Find a node pointed by phandle in a list

--- a/include/dm/ofnode.h
+++ b/include/dm/ofnode.h
@@ -910,6 +910,72 @@ int ofnode_count_phandle_with_args(ofnode node, const char *list_name,
 				   const char *cells_name, int cell_count);
 
 /**
+ * oftree_parse_phandle_with_args() - Find a node pointed by phandle in a list
+ *				      from a root node
+ *
+ * This function is useful to parse lists of phandles and their arguments.
+ * Returns 0 on success and fills out_args, on error returns appropriate
+ * errno value.
+ *
+ * Caller is responsible to call of_node_put() on the returned out_args->np
+ * pointer.
+ *
+ * Example:
+ *
+ * .. code-block::
+ *
+ *   phandle1: node1 {
+ *       #list-cells = <2>;
+ *   };
+ *   phandle2: node2 {
+ *       #list-cells = <1>;
+ *   };
+ *   node3 {
+ *       list = <&phandle1 1 2 &phandle2 3>;
+ *   };
+ *
+ * To get a device_node of the `node2' node you may call this:
+ * oftree_parse_phandle_with_args(node3, "list", "#list-cells", 0, 1, &args);
+ *
+ * @tree:	device tree to use
+ * @node:	device tree node containing a list
+ * @list_name:	property name that contains a list
+ * @cells_name:	property name that specifies phandles' arguments count
+ * @cell_count: Cell count to use if @cells_name is NULL
+ * @index:	index of a phandle to parse out
+ * @out_args:	optional pointer to output arguments structure (will be filled)
+ * Return:
+ *   0 on success (with @out_args filled out if not NULL), -ENOENT if
+ *   @list_name does not exist, -EINVAL if a phandle was not found,
+ *   @cells_name could not be found, the arguments were truncated or there
+ *   were too many arguments.
+ */
+int oftree_parse_phandle_with_args(oftree tree, ofnode node, const char *list_name,
+				   const char *cells_name, int cell_count,
+				   int index,
+				   struct ofnode_phandle_args *out_args);
+
+/**
+ * oftree_count_phandle_with_args() - Count number of phandle in a list
+ *				      from a root node
+ *
+ * This function is useful to count phandles into a list.
+ * Returns number of phandle on success, on error returns appropriate
+ * errno value.
+ *
+ * @tree:	device tree to use
+ * @node:	device tree node containing a list
+ * @list_name:	property name that contains a list
+ * @cells_name:	property name that specifies phandles' arguments count
+ * @cell_count: Cell count to use if @cells_name is NULL
+ * Return:
+ *   number of phandle on success, -ENOENT if @list_name does not exist,
+ *   -EINVAL if a phandle was not found, @cells_name could not be found.
+ */
+int oftree_count_phandle_with_args(oftree tree, ofnode node, const char *list_name,
+				   const char *cells_name, int cell_count);
+
+/**
  * ofnode_path() - find a node by full path
  *
  * This uses the control FDT.

--- a/include/dm/ofnode.h
+++ b/include/dm/ofnode.h
@@ -1721,6 +1721,21 @@ int ofnode_options_read_int(const char *prop_name, int default_val);
 const char *ofnode_options_read_str(const char *prop_name);
 
 /**
+ * ofnode_options_get_by_phandle() - Get a ofnode from phandle from the U-Boot options
+ *
+ * This reads a property from the /options/u-boot/ node of the devicetree.
+ *
+ * This only works with the control FDT.
+ *
+ * See dtschema/schemas/options/u-boot.yaml in dt-schema project for bindings
+ *
+ * @prop_name: property name to look up
+ * @nodep: pointer to ofnode where node is stored
+ * Return: 0, if found, or negative error if not
+ */
+int ofnode_options_get_by_phandle(const char *prop_name, ofnode *nodep);
+
+/**
  * ofnode_read_bootscript_address() - Read bootscr-address or bootscr-ram-offset
  *
  * @bootscr_address: pointer to 64bit address where bootscr-address property value

--- a/test/dm/led.c
+++ b/test/dm/led.c
@@ -144,7 +144,7 @@ static int dm_test_led_boot(struct unit_test_state *uts)
 {
 	struct udevice *dev
 
-	/* options/u-boot/boot-led is set to "sandbox:green" */
+	/* options/u-boot/boot-led is set to phandle to "sandbox:green" */
 	ut_assertok(led_get_by_label("sandbox:green", &dev));
 	ut_asserteq(LEDST_OFF, led_get_state(dev));
 	ut_assertok(led_boot_on());
@@ -154,14 +154,15 @@ static int dm_test_led_boot(struct unit_test_state *uts)
 
 	return 0;
 }
+DM_TEST(dm_test_led_boot, UTF_SCAN_PDATA | UTF_SCAN_FDT);
 
 /* Test LED boot blink fallback */
 #ifndef CONFIG_LED_BLINK
-static int dm_test_led_boot(struct unit_test_state *uts)
+static int dm_test_led_boot_blink(struct unit_test_state *uts)
 {
 	struct udevice *dev
 
-	/* options/u-boot/boot-led is set to "sandbox:green" */
+	/* options/u-boot/boot-led is set to phandle to "sandbox:green" */
 	ut_assertok(led_get_by_label("sandbox:green", &dev));
 	ut_asserteq(LEDST_OFF, led_get_state(dev));
 	ut_assertok(led_boot_blink());
@@ -171,16 +172,17 @@ static int dm_test_led_boot(struct unit_test_state *uts)
 
 	return 0;
 }
+DM_TEST(dm_test_led_boot_blink, UTF_SCAN_PDATA | UTF_SCAN_FDT);
 #endif
 #endif
 
 /* Test LED activity */
 #ifdef CONFIG_LED_ACTIVITY
-static int dm_test_led_boot(struct unit_test_state *uts)
+static int dm_test_led_activity(struct unit_test_state *uts)
 {
 	struct udevice *dev
 
-	/* options/u-boot/activity-led is set to "sandbox:red" */
+	/* options/u-boot/activity-led is set to phandle to "sandbox:red" */
 	ut_assertok(led_get_by_label("sandbox:red", &dev));
 	ut_asserteq(LEDST_OFF, led_get_state(dev));
 	ut_assertok(led_activity_on());
@@ -190,14 +192,15 @@ static int dm_test_led_boot(struct unit_test_state *uts)
 
 	return 0;
 }
+DM_TEST(dm_test_led_activity, UTF_SCAN_PDATA | UTF_SCAN_FDT);
 
 /* Test LED activity blink fallback */
 #ifndef CONFIG_LED_BLINK
-static int dm_test_led_boot(struct unit_test_state *uts)
+static int dm_test_led_activityt_blink(struct unit_test_state *uts)
 {
 	struct udevice *dev
 
-	/* options/u-boot/activity-led is set to "sandbox:red" */
+	/* options/u-boot/activity-led is set to phandle to "sandbox:red" */
 	ut_assertok(led_get_by_label("sandbox:red", &dev));
 	ut_asserteq(LEDST_OFF, led_get_state(dev));
 	ut_assertok(led_activity_blink());
@@ -207,5 +210,6 @@ static int dm_test_led_boot(struct unit_test_state *uts)
 
 	return 0;
 }
+DM_TEST(dm_test_led_activityt_blink, UTF_SCAN_PDATA | UTF_SCAN_FDT);
 #endif
 #endif

--- a/test/dm/ofnode.c
+++ b/test/dm/ofnode.c
@@ -704,6 +704,10 @@ static int dm_test_ofnode_options(struct unit_test_state *uts)
 {
 	u64 bootscr_address, bootscr_offset;
 	u64 bootscr_flash_offset, bootscr_flash_size;
+	ofnode node, phandle_node, target;
+
+	node = ofnode_path("/options/u-boot");
+	ut_assert(ofnode_valid(node));
 
 	ut_assert(!ofnode_options_read_bool("missing"));
 	ut_assert(ofnode_options_read_bool("testing-bool"));
@@ -713,6 +717,13 @@ static int dm_test_ofnode_options(struct unit_test_state *uts)
 
 	ut_assertnull(ofnode_options_read_str("missing"));
 	ut_asserteq_str("testing", ofnode_options_read_str("testing-str"));
+
+	ut_asserteq(-EINVAL, ofnode_options_get_by_phandle("missing", &phandle_node));
+
+	target = ofnode_path("/phandle-node-1");
+	ut_assert(ofnode_valid(target));
+	ut_assertok(ofnode_options_get_by_phandle("testing-phandle", &phandle_node));
+	ut_assert(ofnode_equal(target, phandle_node));
 
 	ut_assertok(ofnode_read_bootscript_address(&bootscr_address,
 						   &bootscr_offset));

--- a/test/dm/ofnode.c
+++ b/test/dm/ofnode.c
@@ -280,15 +280,16 @@ static int dm_test_ofnode_read_ot(struct unit_test_state *uts)
 }
 DM_TEST(dm_test_ofnode_read_ot, UTF_SCAN_FDT | UTF_OTHER_FDT);
 
-/* test ofnode_count_/parse_phandle_with_args() */
+/* test ofnode_count_/parse/_phandle_with_args() */
 static int dm_test_ofnode_phandle(struct unit_test_state *uts)
 {
 	struct ofnode_phandle_args args;
-	ofnode node;
+	ofnode node, phandle, target;
 	int ret;
 	const char prop[] = "test-gpios";
 	const char cell[] = "#gpio-cells";
 	const char prop2[] = "phandle-value";
+	const char prop3[] = "phandle-nodes";
 
 	node = ofnode_path("/a-test");
 	ut_assert(ofnode_valid(node));
@@ -352,20 +353,38 @@ static int dm_test_ofnode_phandle(struct unit_test_state *uts)
 	ret = ofnode_parse_phandle_with_args(node, prop2, NULL, 1, 3, &args);
 	ut_asserteq(-ENOENT, ret);
 
+	/* Test ofnode_parse_phandle */
+	phandle = ofnode_parse_phandle(node, "missing", 0);
+	ut_assert(ofnode_equal(ofnode_null(), phandle));
+
+	target = ofnode_path("/phandle-node-1");
+	ut_assert(ofnode_valid(target));
+	phandle = ofnode_parse_phandle(node, prop3, 0);
+	ut_assert(ofnode_equal(target, phandle));
+
+	target = ofnode_path("/phandle-node-2");
+	ut_assert(ofnode_valid(target));
+	phandle = ofnode_parse_phandle(node, prop3, 1);
+	ut_assert(ofnode_equal(target, phandle));
+
+	phandle = ofnode_parse_phandle(node, prop3, 3);
+	ut_assert(ofnode_equal(ofnode_null(), phandle));
+
 	return 0;
 }
 DM_TEST(dm_test_ofnode_phandle, UTF_SCAN_PDATA | UTF_SCAN_FDT);
 
-/* test oftree_count_/parse_phandle_with_args() with 'other' tree */
+/* test oftree_count_/parse/_phandle_with_args() with 'other' tree */
 static int dm_test_ofnode_phandle_ot(struct unit_test_state *uts)
 {
 	oftree otree = get_other_oftree(uts);
 	struct ofnode_phandle_args args;
-	ofnode node;
+	ofnode node, phandle, target;
 	int ret;
 	const char prop[] = "other-test-gpios";
 	const char cell[] = "#gpio-cells";
 	const char prop2[] = "other-phandle-value";
+	const char prop3[] = "other-phandle-nodes";
 
 	node = oftree_path(otree, "/other-a-test");
 	ut_assert(ofnode_valid(node));
@@ -428,6 +447,23 @@ static int dm_test_ofnode_phandle_ot(struct unit_test_state *uts)
 	ut_asserteq(30, args.args[0]);
 	ret = oftree_parse_phandle_with_args(otree, node, prop2, NULL, 1, 3, &args);
 	ut_asserteq(-ENOENT, ret);
+
+	/* Test oftree_parse_phandle */
+	phandle = oftree_parse_phandle(otree, node, "missing", 0);
+	ut_assert(ofnode_equal(ofnode_null(), phandle));
+
+	target = oftree_path(otree, "/other-phandle-node-1");
+	ut_assert(ofnode_valid(target));
+	phandle = oftree_parse_phandle(otree, node, prop3, 0);
+	ut_assert(ofnode_equal(target, phandle));
+
+	target = oftree_path(otree, "/other-phandle-node-2");
+	ut_assert(ofnode_valid(target));
+	phandle = oftree_parse_phandle(otree, node, prop3, 1);
+	ut_assert(ofnode_equal(target, phandle));
+
+	phandle = oftree_parse_phandle(otree, node, prop3, 3);
+	ut_assert(ofnode_equal(ofnode_null(), phandle));
 
 	return 0;
 }


### PR DESCRIPTION
Update LED boot/activity to reference by phandle instead of label.
This is a followup request by dt-schema maintainers that required LED
node to be referenced by a phandle to the node instead of indirectly by
the LED label.

While at it generalize the LED node label parsing since the logic is
common for generic LED bind and LED activity/boot.