### PR TITLE
image: fdt: don't try to reserve memory above ram_top

### DIFF
--- a/boot/image-fdt.c
+++ b/boot/image-fdt.c
@@ -72,6 +72,9 @@ static void boot_fdt_reserve_region(u64 addr, u64 size, enum lmb_flags flags)
 {
 	long ret;
 
+	if (addr >= (u64)gd->ram_top)
+		return;
+
 	ret = lmb_reserve_flags(addr, size, flags);
 	if (!ret) {
 		debug("   reserving fdt memory region: addr=%llx size=%llx flags=%x\n",


### PR DESCRIPTION
The boot_fdt_add_mem_rsv_regions() function is called for reserving in LMB memory map, regions marked as so in the device-tree. This is done to prevent using these regions for loading any images. The region above ram_top is now marked as reserved with the LMB_NOOVERWRITE flag during the board init. This results in a false alarm in form of an error message when the memory region is above ram_top, and the boot_fdt_add_mem_rsv_regions() function tries to reserve that region. Do not try to reserve these regions above ram_top.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
