### PR TITLE
fdt_support: improve board_fdt_chosen_bootargs() for flexibility

### DIFF
--- a/boot/fdt_support.c
+++ b/boot/fdt_support.c
@@ -321,7 +321,7 @@ int fdt_kaslrseed(void *fdt, bool overwrite)
  * board_fdt_chosen_bootargs - boards may override this function to use
  *                             alternative kernel command line arguments
  */
-__weak char *board_fdt_chosen_bootargs(void)
+__weak const char *board_fdt_chosen_bootargs(void)
 {
 	return env_get("bootargs");
 }
@@ -331,7 +331,7 @@ int fdt_chosen(void *fdt)
 	struct abuf buf = {};
 	int   nodeoffset;
 	int   err;
-	char  *str;		/* used to set string properties */
+	const char *str;		/* used to set string properties */
 
 	err = fdt_check_header(fdt);
 	if (err < 0) {

--- a/boot/fdt_support.c
+++ b/boot/fdt_support.c
@@ -321,7 +321,7 @@ int fdt_kaslrseed(void *fdt, bool overwrite)
  * board_fdt_chosen_bootargs - boards may override this function to use
  *                             alternative kernel command line arguments
  */
-__weak const char *board_fdt_chosen_bootargs(void)
+__weak const char *board_fdt_chosen_bootargs(const struct fdt_property *fdt_ba)
 {
 	return env_get("bootargs");
 }
@@ -364,7 +364,8 @@ int fdt_chosen(void *fdt)
 		}
 	}
 
-	str = board_fdt_chosen_bootargs();
+	str = board_fdt_chosen_bootargs(fdt_get_property(fdt, nodeoffset,
+							 "bootargs", NULL));
 
 	if (str) {
 		err = fdt_setprop(fdt, nodeoffset, "bootargs", str,

--- a/include/fdt_support.h
+++ b/include/fdt_support.h
@@ -218,7 +218,7 @@ int board_rng_seed(struct abuf *buf);
  *
  * @return: pointer to kernel command line arguments in memory
  */
-char *board_fdt_chosen_bootargs(void);
+const char *board_fdt_chosen_bootargs(void);
 
 /*
  * The keystone2 SOC requires all 32 bit aliased addresses to be converted

--- a/include/fdt_support.h
+++ b/include/fdt_support.h
@@ -216,9 +216,10 @@ int board_rng_seed(struct abuf *buf);
  * This is used for late modification of kernel command line arguments just
  * before they are added into the /chosen node in flat device tree.
  *
+ * @param fdt_ba FDT chosen/bootargs from the kernel image if available
  * @return: pointer to kernel command line arguments in memory
  */
-const char *board_fdt_chosen_bootargs(void);
+const char *board_fdt_chosen_bootargs(const struct fdt_property *fdt_ba);
 
 /*
  * The keystone2 SOC requires all 32 bit aliased addresses to be converted


### PR DESCRIPTION
This series consists of two patches.

The first patch modifies the board_fdt_chosen_bootargs() function to
return a const char* type. This change clarifies to the caller that the
returned string should neither be freed nor modified. It aligns with the
existing fdt_setprop() function, which already utilizes a const char*
parameter. This promotes consistency within the codebase and enhances
code safety by preventing unintended modifications to the returned
string.

The second patch addresses the need for flexibility in providing kernel
command line arguments (bootargs) for different kernel images within the
same U-Boot environment. It introduces a read-only (RO) fdt_property
argument to the board_fdt_chosen_bootargs() function, allowing access to
the original chosen/bootargs data. This is crucial for scenarios where
different kernel versions require distinct console setups (e.g., ttyS0
for vendor kernels and ttyAML0 for upstream kernels). By enabling board
developers to either merge or replace the original bootargs, this
patch enhances the configurability of U-Boot for various kernel
images without relying on outdated configurations like CMDLINE_EXTEND.

Signed-off-by: Dmitry Rokosov <ddrokosov@salutedevices.com>