### PR TITLE
i2c: Fix remaining stack buffer overflow vulnerability in i2c md command

### DIFF
--- a/cmd/i2c.c
+++ b/cmd/i2c.c
@@ -468,8 +468,8 @@ static int do_i2c_md(struct cmd_tbl *cmdtp, int flag, int argc,
 {
 	uint	chip;
 	uint	addr, length;
-	int alen;
-	int j;
+	uint alen;
+	uint j;
 	uint nbytes, linebytes;
 	int ret;
 #if CONFIG_IS_ENABLED(DM_I2C)


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in the do_i2c_md() function by changing the variable types of alen and j from signed to unsigned integers. The original vulnerability was partially fixed in commit 8f8c04bf1ebbd2f72f1643e7ad9617dafa6e5409, which changed nbytes and linebytes to unsigned, but left alen and j as signed integers.
When large values are used, signed integers can overflow and become negative, potentially leading to buffer overflows when used with memory operations. This PR completes the fix by ensuring all size-related variables use unsigned types.
I identified this issue while conducting code similarity analysis and vulnerability detection research on cloned code across repositories. While the critical variables nbytes and linebytes were properly changed to unsigned, the alen variable remained signed, leaving part of the vulnerability unfixed.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2022-4283
https://github.com/u-boot/u-boot/commit/8f8c04bf1ebbd2f72f1643e7ad9617dafa6e5409