### PR TITLE
efi: Fix efiboot for payloads loaded from memory

### DIFF
--- a/lib/efi_loader/efi_bootbin.c
+++ b/lib/efi_loader/efi_bootbin.c
@@ -268,6 +268,9 @@ efi_status_t efi_binary_run(void *image, size_t size, void *fdt)
 							       file_path, NULL);
 		if (ret != EFI_SUCCESS)
 			goto out;
+
+		bootefi_device_path = file_path;
+		bootefi_image_path = NULL;
 	} else {
 		log_debug("Loaded from disk\n");
 	}


### PR DESCRIPTION
Calling bootefi on an address that was loaded from memory (e.g., cramfs or SPI flash via "sf read", etc.), currently results in the EFI binary not being able to access the EFI image device path.

For example, iPXE would fail with an error "EFI could not get loaded image's device path: Error 0x7f39e082 (https://ipxe.org/7f39e082)".

This is due to an incomplete special-case in efi_binary_run, where a new device path was created but not used in all required places.

Fix the in-memory special case, set the "bootefi_device_path" to the generated "file_path".

iPXE will now boot, and report the device path as
"/MemoryMapped(0x0,0xSTART,0xLEN)"

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
