### PR TITLE
mbedtls: remove incorrect attribute type checker

### DIFF
--- a/lib/mbedtls/pkcs7_parser.c
+++ b/lib/mbedtls/pkcs7_parser.c
@@ -189,10 +189,6 @@ static int authattrs_parse(struct pkcs7_message *msg, void *aa, size_t aa_len,
 						len)) {
 			if (__test_and_set_bit(sinfo_has_smime_caps, &sinfo->aa_set))
 				return -EINVAL;
-
-			if (msg->data_type != OID_msIndirectData &&
-			    msg->data_type != OID_data)
-				return -EINVAL;
 		} else if (!MBEDTLS_OID_CMP_RAW(MBEDTLS_OID_MICROSOFT_SPOPUSINFO, inner_p,
 						len)) {
 			if (__test_and_set_bit(sinfo_has_ms_opus_info, &sinfo->aa_set))


### PR DESCRIPTION
S/MIME Capabilities (OID: 1.2.840.113549.1.9.15) attributes are expected to be algorithms but neither data nor MS Inderect Data, thus the checker is incorrect.

This patch fixes a capsule authentication failure with PKCS#7 message that contains S/MIME capabilities, which formed by the EDK2 GenerateCapsule tool.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
