### PR TITLE
efi_loader: Moved the generated ESL file to objtree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ fit-dtb.blob*
 /drivers/video/u_boot_logo.S
 /test/overlay/test-fdt-overlay.dtbo.S
 /test/overlay/test-fdt-overlay-stacked.dtbo.S
+capsule_esl_file
 
 #
 # Generated include files

--- a/Makefile
+++ b/Makefile
@@ -2231,7 +2231,7 @@ CLEAN_FILES += include/autoconf.mk* include/bmp_logo.h include/bmp_logo_data.h \
 	       itb.fit.fit itb.fit.itb itb.map spl.map mkimage-out.rom.mkimage \
 	       mkimage.rom.mkimage mkimage-in-simple-bin* rom.map simple-bin* \
 	       idbloader-spi.img lib/efi_loader/helloworld_efi.S *.itb \
-	       Test* capsule*.*.efi-capsule capsule*.map capsule_esl_file
+	       Test* capsule*.*.efi-capsule capsule*.map
 
 # Directories & files removed with 'make mrproper'
 MRPROPER_DIRS  += include/config include/generated spl tpl vpl \

--- a/lib/efi_loader/Makefile
+++ b/lib/efi_loader/Makefile
@@ -79,7 +79,7 @@ capsule_crt_path=($(subst $(quote),,$(CONFIG_EFI_CAPSULE_CRT_FILE)))
 capsule_crt_full=$(srctree)/$(subst $(quote),,$(CONFIG_EFI_CAPSULE_CRT_FILE))
 quiet_cmd_capsule_esl_gen = CAPSULE_ESL_GEN $@
 cmd_capsule_esl_gen = cert-to-efi-sig-list $(capsule_crt_full) $@
-$(srctree)/capsule_esl_file: FORCE
+$(objtree)/capsule_esl_file: FORCE
 	@if [ ! -e "$(capsule_crt_full)" ]; then \
 		echo "ERROR: path $(capsule_crt_full) is invalid." >&2; \
 		echo "EFI CONFIG_EFI_CAPSULE_CRT_FILE must be specified when CONFIG_EFI_CAPSULE_AUTHENTICATE is enabled." >&2; \
@@ -87,8 +87,8 @@ $(srctree)/capsule_esl_file: FORCE
 	fi
 	$(call cmd,capsule_esl_gen)
 
-$(obj)/efi_capsule.o: $(srctree)/capsule_esl_file FORCE
-asflags-y += -DCAPSULE_ESL_PATH=\"$(srctree)/capsule_esl_file\"
+$(obj)/efi_capsule.o: $(objtree)/capsule_esl_file FORCE
+asflags-y += -DCAPSULE_ESL_PATH=\"$(objtree)/capsule_esl_file\"
 endif
 
 # Set the C flags to add and remove for each app


### PR DESCRIPTION
Tom reports that generating the ESL file we need for authenticated capsule updates fails to work on azure which expects a RO git tree.

Move it to $(objtree)

Reported-by: Tom Rini <trini@konsulko.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
