### PR TITLE
common: readline: Fix always true test

### DIFF
--- a/common/cli_readline.c
+++ b/common/cli_readline.c
@@ -333,9 +333,9 @@ int cread_line_process_ch(struct cli_line_state *cls, char ichar)
 			uint base, wlen;
 
 			for (base = cls->num - 1;
-			     base >= 0 && buf[base] == ' ';)
+			     base > 0 && buf[base] == ' ';)
 				base--;
-			for (; base > 0 && buf[base - 1] != ' ';)
+			for (; base > 1 && buf[base - 1] != ' ';)
 				base--;
 
 			/* now delete chars from base to cls->num */


### PR DESCRIPTION
The variable base is unsigned so >= 0 is always true. Fix this test so that it is actually useful.

Fixes: dcc18ce0dbaf ("cli: Implement delete-word in cread_line()")

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
