### PR TITLE
common: readline: Fix always true test

### DIFF
--- a/common/cli_readline.c
+++ b/common/cli_readline.c
@@ -332,10 +332,10 @@ int cread_line_process_ch(struct cli_line_state *cls, char ichar)
 		if (cls->num) {
 			uint base, wlen;
 
-			for (base = cls->num - 1;
-			     base >= 0 && buf[base] == ' ';)
+			for (base = cls->num;
+			     base > 0 && buf[base - 1] == ' ';)
 				base--;
-			for (; base > 0 && buf[base - 1] != ' ';)
+			for (; base > 1 && buf[base - 2] != ' ';)
 				base--;
 
 			/* now delete chars from base to cls->num */


### PR DESCRIPTION
The variable base is unsigned so >= 0 is always true. Fix this test
so that it is actually useful.
    
Fixes: dcc18ce0dbaf ("cli: Implement delete-word in cread_line()")
Signed-off-by: Andrew Goodbody <andrew.goodbody@linaro.org>