### PR TITLE
net: ti: icssg: Read firmware name from device-tree

### DIFF
--- a/drivers/net/ti/icssg_prueth.h
+++ b/drivers/net/ti/icssg_prueth.h
@@ -38,6 +38,12 @@ enum prueth_port {
 	PRUETH_PORT_MII1,	/* physical port MII 1 */
 };
 
+struct icssg_firmwares {
+	char *pru;
+	char *rtu;
+	char *txpru;
+};
+
 struct prueth {
 	struct udevice		*dev;
 	struct udevice		*pruss;
@@ -66,6 +72,7 @@ struct prueth {
 	u8			rtu_core_id;
 	u8			txpru_core_id;
 	u8			icssg_hwcmdseq;
+	struct icssg_firmwares  firmwares[PRUETH_NUM_MACS];
 };
 
 struct prueth_priv {


### PR DESCRIPTION
Update the ICSSG PRU Ethernet driver to read PRU/RTU/TXPRU firmware names from the Device Tree using the "firmware-name" property, instead of relying on the hard-coded firmware names. The firmware names are parsed during prueth_probe() and stored in the prueth->firmwares for each slice. The driver now uses these dynamically loaded names when starting the PRU cores.

This change improves flexibility and allows firmware selection to be controlled via the device tree, making the driver more adaptable to different platforms and firmware configurations.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
