### PR TITLE
implement tools and handling for FIT `install-uuid`

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1521,6 +1521,12 @@ S:	Orphaned (Since 2017-01)
 T:	git https://source.denx.de/u-boot/custodians/u-boot-onenand.git
 F:	drivers/mtd/onenand/
 
+OPENWRT BOOT EXTENSIONS
+M:	Daniel Golle <daniel@makrotopia.org>
+L:	openwrt-devel@lists.openwrt.org
+S:	Maintained
+F:	tools/fit_set_uuid.c
+
 OUT4-IMX6ULL-NANO BOARD
 M:	Oleh Kravchenko <oleg@kaa.org.ua>
 S:	Maintained

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1525,6 +1525,7 @@ OPENWRT BOOT EXTENSIONS
 M:	Daniel Golle <daniel@makrotopia.org>
 L:	openwrt-devel@lists.openwrt.org
 S:	Maintained
+F:	cmd/fit.c
 F:	tools/fit_set_uuid.c
 
 OUT4-IMX6ULL-NANO BOARD

--- a/boot/bootm.c
+++ b/boot/bootm.c
@@ -130,6 +130,8 @@ static int boot_get_kernel(const char *addr_fit, struct bootm_headers *images,
 	const char *fit_uname_config = NULL, *fit_uname_kernel = NULL;
 #if CONFIG_IS_ENABLED(FIT)
 	int		os_noffset;
+	int		uuid_len;
+	const		void *uuid;
 #endif
 
 #ifdef CONFIG_ANDROID_BOOT_IMAGE
@@ -204,6 +206,14 @@ static int boot_get_kernel(const char *addr_fit, struct bootm_headers *images,
 		images->fit_uname_os = fit_uname_kernel;
 		images->fit_uname_cfg = fit_uname_config;
 		images->fit_noffset_os = os_noffset;
+
+		/* Save install-uuid now while FIT is readable */
+		uuid = fdt_getprop(images->fit_hdr_os, 0,
+				   FIT_INSTALL_UUID_PROP,
+				   &uuid_len);
+		if (uuid && uuid_len == FIT_INSTALL_UUID_LEN)
+			memcpy(images->fit_install_uuid, uuid,
+			       FIT_INSTALL_UUID_LEN);
 		break;
 #endif
 #ifdef CONFIG_ANDROID_BOOT_IMAGE

--- a/boot/image-fdt.c
+++ b/boot/image-fdt.c
@@ -637,6 +637,17 @@ int image_setup_libfdt(struct bootm_headers *images, void *blob, bool lmb)
 					images->fit_uname_cfg,
 					strlen(images->fit_uname_cfg) + 1, 1);
 
+	/*
+	 * Copy install-uuid (saved at FIT parse time) into /chosen.
+	 * Byte 8 carries the RFC 4122 variant bits (10xxxxxx for all
+	 * standard UUIDs), so it is never zero for a valid UUID while
+	 * the zero-initialized default reliably indicates "not set".
+	 */
+	if (images->fit_install_uuid[8])
+		fdt_find_and_setprop(blob, "/chosen", "u-boot,fit-install-uuid",
+				     images->fit_install_uuid,
+				     FIT_INSTALL_UUID_LEN, 1);
+
 	/* Update ethernet nodes */
 	fdt_fixup_ethernet(blob);
 #if IS_ENABLED(CONFIG_CMD_PSTORE)

--- a/cmd/Kconfig
+++ b/cmd/Kconfig
@@ -565,6 +565,16 @@ config CMD_FDT
 	help
 	  Do FDT related setup before booting into the Operating System.
 
+config CMD_FIT
+	bool "fit - FIT image utilities"
+	depends on FIT
+	select RANDOM_UUID
+	help
+	  Provides the "fit" command for manipulating FIT images stored
+	  in memory.  Currently supports:
+
+	    fit setuuid <addr> - stamp a random install-uuid into a FIT
+
 config CMD_EXTENSION
 	bool "Extension board management command"
 	select CMD_FDT

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -83,6 +83,7 @@ obj-$(CONFIG_CMD_EXT4) += ext4.o
 obj-$(CONFIG_CMD_EXT2) += ext2.o
 obj-$(CONFIG_CMD_FAT) += fat.o
 obj-$(CONFIG_CMD_FDT) += fdt.o
+obj-$(CONFIG_CMD_FIT) += fit.o
 obj-$(CONFIG_CMD_SQUASHFS) += sqfs.o
 obj-$(CONFIG_CMD_SELECT_FONT) += font.o
 obj-$(CONFIG_CMD_FLASH) += flash.o

--- a/cmd/fit.c
+++ b/cmd/fit.c
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * FIT image utility commands
+ *
+ * Copyright (C) 2026 Daniel Golle <daniel@makrotopia.org>
+ */
+
+#include <command.h>
+#include <image.h>
+#include <mapmem.h>
+#include <linux/libfdt.h>
+#include <u-boot/uuid.h>
+
+static int do_fit_setuuid(struct cmd_tbl *cmdtp, int flag,
+			  int argc, char *const argv[])
+{
+	unsigned char uuid_bin[FIT_INSTALL_UUID_LEN];
+	char uuid_str[UUID_STR_LEN + 1];
+	ulong addr;
+	void *fit;
+	int ret;
+
+	if (argc != 2)
+		return CMD_RET_USAGE;
+
+	addr = hextoul(argv[1], NULL);
+	fit = map_sysmem(addr, 0);
+
+	if (fdt_check_header(fit)) {
+		printf("Bad FIT header at %#lx\n", addr);
+		ret = CMD_RET_FAILURE;
+		goto out;
+	}
+
+	gen_rand_uuid(uuid_bin);
+
+	if (fdt_setprop_inplace(fit, 0, FIT_INSTALL_UUID_PROP,
+				uuid_bin, FIT_INSTALL_UUID_LEN)) {
+		printf("Cannot set %s (missing or wrong-size property)\n",
+		       FIT_INSTALL_UUID_PROP);
+		ret = CMD_RET_FAILURE;
+		goto out;
+	}
+
+	uuid_bin_to_str(uuid_bin, uuid_str, UUID_STR_FORMAT_STD);
+	printf("Set %s = %s\n", FIT_INSTALL_UUID_PROP, uuid_str);
+	ret = CMD_RET_SUCCESS;
+out:
+	unmap_sysmem(fit);
+	return ret;
+}
+
+U_BOOT_LONGHELP(fit,
+	"setuuid <addr> - stamp random install-uuid into FIT at <addr>\n"
+);
+
+U_BOOT_CMD_WITH_SUBCMDS(fit, "FIT image utilities", fit_help_text,
+			U_BOOT_SUBCMD_MKENT(setuuid, 2, 0, do_fit_setuuid));

--- a/include/image.h
+++ b/include/image.h
@@ -1065,6 +1065,8 @@ int booti_setup(ulong image, ulong *relocated_addr, ulong *size,
 
 #define FIT_IMAGES_PATH		"/images"
 #define FIT_CONFS_PATH		"/configurations"
+#define FIT_INSTALL_UUID_PROP	"install-uuid"
+#define FIT_INSTALL_UUID_LEN	16
 
 /* hash/signature/key node */
 #define FIT_HASH_NODENAME	"hash"

--- a/include/image.h
+++ b/include/image.h
@@ -369,6 +369,7 @@ struct bootm_headers {
 	void		*fit_hdr_os;	/* os FIT image header */
 	const char	*fit_uname_os;	/* os subimage node unit name */
 	int		fit_noffset_os;	/* os subimage node offset */
+	uint8_t		fit_install_uuid[16]; /* install-uuid from FIT root */
 
 	void		*fit_hdr_rd;	/* init ramdisk FIT image header */
 	const char	*fit_uname_rd;	/* init ramdisk subimage node unit name */

--- a/test/cmd/Makefile
+++ b/test/cmd/Makefile
@@ -19,6 +19,7 @@ endif
 obj-$(CONFIG_CMD_BDI) += bdinfo.o
 obj-$(CONFIG_COREBOOT_SYSINFO) += coreboot.o
 obj-$(CONFIG_CMD_FDT) += fdt.o
+obj-$(CONFIG_CMD_FIT) += fit.o
 obj-$(CONFIG_CMD_HASH) += hash.o
 obj-$(CONFIG_CMD_HISTORY) += history.o
 obj-$(CONFIG_CMD_I3C) += i3c.o

--- a/test/cmd/fit.c
+++ b/test/cmd/fit.c
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Tests for fit command
+ *
+ * Copyright (C) 2026 Daniel Golle <daniel@makrotopia.org>
+ */
+
+#include <console.h>
+#include <image.h>
+#include <mapmem.h>
+#include <linux/libfdt.h>
+#include <u-boot/uuid.h>
+#include <test/ut.h>
+
+/* Declare a new fit test */
+#define FIT_TEST(_name, _flags)	UNIT_TEST(_name, _flags, fit)
+
+/**
+ * make_fit_with_uuid() - Create a minimal FIT (FDT) with an install-uuid prop
+ *
+ * Uses the sequential fdt_create() API to build a minimal FDT root node
+ * containing an "install-uuid" property of the specified size, filled with
+ * zeroes.
+ *
+ * @uts: Test state
+ * @fdt: Buffer to write FDT into
+ * @size: Size of the buffer
+ * @uuid_prop_len: Length of the install-uuid property to create (use
+ *                 FIT_INSTALL_UUID_LEN for the correct size)
+ * @addrp: Returns sandbox address of the FDT
+ * Return: 0 on success
+ */
+static int make_fit_with_uuid(struct unit_test_state *uts, void *fdt,
+			      int size, int uuid_prop_len, ulong *addrp)
+{
+	unsigned char zeros[FIT_INSTALL_UUID_LEN] = { 0 };
+
+	ut_assertok(fdt_create(fdt, size));
+	ut_assertok(fdt_finish_reservemap(fdt));
+	ut_assert(fdt_begin_node(fdt, "") >= 0);
+	ut_assertok(fdt_property(fdt, FIT_INSTALL_UUID_PROP,
+				 zeros, uuid_prop_len));
+	ut_assertok(fdt_end_node(fdt));
+	ut_assertok(fdt_finish(fdt));
+
+	*addrp = map_to_sysmem(fdt);
+
+	return 0;
+}
+
+/**
+ * make_fit_no_uuid() - Create a minimal FIT (FDT) without install-uuid
+ *
+ * @uts: Test state
+ * @fdt: Buffer to write FDT into
+ * @size: Size of the buffer
+ * @addrp: Returns sandbox address of the FDT
+ * Return: 0 on success
+ */
+static int make_fit_no_uuid(struct unit_test_state *uts, void *fdt,
+			    int size, ulong *addrp)
+{
+	ut_assertok(fdt_create(fdt, size));
+	ut_assertok(fdt_finish_reservemap(fdt));
+	ut_assert(fdt_begin_node(fdt, "") >= 0);
+	ut_assertok(fdt_property_string(fdt, "description",
+					"test FIT image"));
+	ut_assertok(fdt_end_node(fdt));
+	ut_assertok(fdt_finish(fdt));
+
+	*addrp = map_to_sysmem(fdt);
+
+	return 0;
+}
+
+/**
+ * fit_test_setuuid_usage() - Test that 'fit setuuid' with wrong argc fails
+ *
+ * Verifies that calling the command with no arguments or too many arguments
+ * returns CMD_RET_USAGE.
+ */
+static int fit_test_setuuid_usage(struct unit_test_state *uts)
+{
+	/* No arguments — should print usage (which also outputs help text) */
+	ut_asserteq(1, run_command("fit setuuid", 0));
+
+	/* Too many arguments — should also print usage */
+	ut_asserteq(1, run_command("fit setuuid 1000 extra", 0));
+
+	return 0;
+}
+FIT_TEST(fit_test_setuuid_usage, UTF_CONSOLE);
+
+/**
+ * fit_test_setuuid_bad_header() - Test 'fit setuuid' with bad FDT header
+ *
+ * Writes garbage data into memory and verifies the command detects an
+ * invalid FIT/FDT header.
+ */
+static int fit_test_setuuid_bad_header(struct unit_test_state *uts)
+{
+	u8 *buf;
+
+	buf = map_sysmem(0x1000, 256);
+	memset(buf, 0xab, 256);   /* garbage — not a valid FDT */
+	unmap_sysmem(buf);
+
+	ut_asserteq(1, run_command("fit setuuid 1000", 0));
+	ut_assert_nextline("Bad FIT header at 0x1000");
+	ut_assert_console_end();
+
+	return 0;
+}
+FIT_TEST(fit_test_setuuid_bad_header, UTF_CONSOLE);
+
+/**
+ * fit_test_setuuid_no_prop() - Test 'fit setuuid' on FDT missing the property
+ *
+ * Creates a valid FDT that has no install-uuid property. The command should
+ * report that it cannot set the property.
+ */
+static int fit_test_setuuid_no_prop(struct unit_test_state *uts)
+{
+	char fdt[512];
+	ulong addr;
+
+	ut_assertok(make_fit_no_uuid(uts, fdt, sizeof(fdt), &addr));
+
+	ut_asserteq(1, run_commandf("fit setuuid %lx", addr));
+	ut_assert_nextline("Cannot set %s (missing or wrong-size property)",
+			   FIT_INSTALL_UUID_PROP);
+	ut_assert_console_end();
+
+	return 0;
+}
+FIT_TEST(fit_test_setuuid_no_prop, UTF_CONSOLE);
+
+/**
+ * fit_test_setuuid_wrong_size() - Test 'fit setuuid' with wrong-size property
+ *
+ * Creates a valid FDT with an install-uuid property that is too small (8
+ * bytes instead of 16). fdt_setprop_inplace() should fail because the sizes
+ * don't match.
+ */
+static int fit_test_setuuid_wrong_size(struct unit_test_state *uts)
+{
+	char fdt[512];
+	ulong addr;
+
+	/* Create property with 8 bytes instead of 16 */
+	ut_assertok(make_fit_with_uuid(uts, fdt, sizeof(fdt), 8, &addr));
+
+	ut_asserteq(1, run_commandf("fit setuuid %lx", addr));
+	ut_assert_nextline("Cannot set %s (missing or wrong-size property)",
+			   FIT_INSTALL_UUID_PROP);
+	ut_assert_console_end();
+
+	return 0;
+}
+FIT_TEST(fit_test_setuuid_wrong_size, UTF_CONSOLE);
+
+/**
+ * fit_test_setuuid_success() - Test successful 'fit setuuid' operation
+ *
+ * Creates a valid FDT with a correctly sized install-uuid property (16
+ * bytes, initially all zeroes). Runs the command and verifies:
+ *   - The command succeeds
+ *   - A "Set install-uuid = <uuid>" line is printed
+ *   - The UUID written into the FDT is non-zero
+ *   - The UUID is a valid version-4 UUID (variant and version bits)
+ */
+static int fit_test_setuuid_success(struct unit_test_state *uts)
+{
+	char fdt[512];
+	ulong addr;
+	const void *prop;
+	int prop_len;
+	const unsigned char *uuid_bin;
+	unsigned char zeros[FIT_INSTALL_UUID_LEN] = { 0 };
+	void *fit;
+
+	ut_assertok(make_fit_with_uuid(uts, fdt, sizeof(fdt),
+				       FIT_INSTALL_UUID_LEN, &addr));
+
+	ut_assertok(run_commandf("fit setuuid %lx", addr));
+
+	/* Verify console output: "Set install-uuid = <uuid-string>" */
+	ut_assert_nextlinen("Set install-uuid = ");
+	ut_assert_console_end();
+
+	/* Read back the property from the FDT */
+	fit = map_sysmem(addr, 0);
+	prop = fdt_getprop(fit, 0, FIT_INSTALL_UUID_PROP, &prop_len);
+	unmap_sysmem(fit);
+
+	ut_assertnonnull(prop);
+	ut_asserteq(FIT_INSTALL_UUID_LEN, prop_len);
+
+	/* UUID must not be all zeroes (it was randomised) */
+	uuid_bin = prop;
+	ut_assert(memcmp(uuid_bin, zeros, FIT_INSTALL_UUID_LEN) != 0);
+
+	/* Verify UUID v4 structure:
+	 *   - version nibble (byte 6, high nibble) == 0x4
+	 *   - variant bits   (byte 8, top 2 bits)  == 0b10
+	 */
+	ut_asserteq(0x40, uuid_bin[6] & 0xf0);
+	ut_asserteq(0x80, uuid_bin[8] & 0xc0);
+
+	return 0;
+}
+FIT_TEST(fit_test_setuuid_success, UTF_CONSOLE);
+
+/**
+ * fit_test_setuuid_idempotent() - Test running 'fit setuuid' twice
+ *
+ * Stamps a UUID, reads it, stamps again, and verifies the second UUID
+ * differs. This confirms gen_rand_uuid() produces distinct values and
+ * that the in-place overwrite works correctly.
+ */
+static int fit_test_setuuid_idempotent(struct unit_test_state *uts)
+{
+	char fdt[512];
+	ulong addr;
+	unsigned char uuid_first[FIT_INSTALL_UUID_LEN];
+	unsigned char uuid_second[FIT_INSTALL_UUID_LEN];
+	const void *prop;
+	int prop_len;
+	void *fit;
+
+	ut_assertok(make_fit_with_uuid(uts, fdt, sizeof(fdt),
+				       FIT_INSTALL_UUID_LEN, &addr));
+
+	/* First stamp */
+	ut_assertok(run_commandf("fit setuuid %lx", addr));
+	ut_assert_nextlinen("Set install-uuid = ");
+	ut_assert_console_end();
+
+	fit = map_sysmem(addr, 0);
+	prop = fdt_getprop(fit, 0, FIT_INSTALL_UUID_PROP, &prop_len);
+	ut_assertnonnull(prop);
+	memcpy(uuid_first, prop, FIT_INSTALL_UUID_LEN);
+	unmap_sysmem(fit);
+
+	/* Second stamp */
+	ut_assertok(run_commandf("fit setuuid %lx", addr));
+	ut_assert_nextlinen("Set install-uuid = ");
+	ut_assert_console_end();
+
+	fit = map_sysmem(addr, 0);
+	prop = fdt_getprop(fit, 0, FIT_INSTALL_UUID_PROP, &prop_len);
+	ut_assertnonnull(prop);
+	memcpy(uuid_second, prop, FIT_INSTALL_UUID_LEN);
+	unmap_sysmem(fit);
+
+	/* The two UUIDs should differ (probability of collision ≈ 0) */
+	ut_assert(memcmp(uuid_first, uuid_second, FIT_INSTALL_UUID_LEN) != 0);
+
+	return 0;
+}
+FIT_TEST(fit_test_setuuid_idempotent, UTF_CONSOLE);

--- a/test/cmd_ut.c
+++ b/test/cmd_ut.c
@@ -59,6 +59,7 @@ SUITE_DECL(env);
 SUITE_DECL(exit);
 SUITE_DECL(fdt);
 SUITE_DECL(fdt_overlay);
+SUITE_DECL(fit);
 SUITE_DECL(font);
 SUITE_DECL(hush);
 SUITE_DECL(lib);
@@ -86,6 +87,7 @@ static struct suite suites[] = {
 	SUITE(exit, "shell exit and variables"),
 	SUITE(fdt, "fdt command"),
 	SUITE(fdt_overlay, "device tree overlays"),
+	SUITE(fit, "fit command"),
 	SUITE(font, "font command"),
 	SUITE(hush, "hush behaviour"),
 	SUITE(lib, "library functions"),

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -63,7 +63,7 @@ HOSTCFLAGS_img2srec.o := -pedantic
 hostprogs-always-y += mkenvimage
 mkenvimage-objs := mkenvimage.o os_support.o generated/lib/crc32.o
 
-hostprogs-always-y += dumpimage mkimage fit_info
+hostprogs-always-y += dumpimage mkimage fit_info fit_set_uuid
 hostprogs-always-$(CONFIG_FIT_SIGNATURE) += fit_check_sign
 hostprogs-always-$(CONFIG_TOOLS_LIBCRYPTO) += fdt_add_pubkey
 hostprogs-always-$(CONFIG_TOOLS_LIBCRYPTO) += preload_check_sign
@@ -166,6 +166,8 @@ dumpimage-mkimage-objs := aisimage.o \
 dumpimage-objs := $(dumpimage-mkimage-objs) dumpimage.o
 mkimage-objs   := $(dumpimage-mkimage-objs) mkimage.o
 fit_info-objs   := $(dumpimage-mkimage-objs) fit_info.o
+fit_set_uuid-objs := $(dumpimage-mkimage-objs) fit_set_uuid.o \
+	generated/lib/uuid.o
 fit_check_sign-objs   := $(dumpimage-mkimage-objs) fit_check_sign.o
 fdt_add_pubkey-objs   := $(dumpimage-mkimage-objs) fdt_add_pubkey.o
 file2include-objs := file2include.o
@@ -207,6 +209,7 @@ HOSTCFLAGS_fit_image.o += -DMKIMAGE_DTC=\"$(CONFIG_MKIMAGE_DTC_PATH)\"
 
 HOSTLDLIBS_dumpimage := $(HOSTLDLIBS_mkimage)
 HOSTLDLIBS_fit_info := $(HOSTLDLIBS_mkimage)
+HOSTLDLIBS_fit_set_uuid := $(HOSTLDLIBS_mkimage)
 HOSTLDLIBS_fit_check_sign := $(HOSTLDLIBS_mkimage)
 HOSTLDLIBS_fdt_add_pubkey := $(HOSTLDLIBS_mkimage)
 HOSTLDLIBS_preload_check_sign := $(HOSTLDLIBS_mkimage)

--- a/tools/fit_set_uuid.c
+++ b/tools/fit_set_uuid.c
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * fit_set_uuid - stamp, read, or manage install-uuid in FIT images
+ *
+ * Copyright (C) 2026 Daniel Golle <daniel@makrotopia.org>
+ *
+ * Modes:
+ *   fit_set_uuid -f <file>              Generate and stamp a new UUID
+ *   fit_set_uuid -f <file> -u <uuid>    Stamp a specific UUID
+ *   fit_set_uuid -g -f <file>           Print existing UUID to stdout
+ *   fit_set_uuid -m -f <file>           Match UUID against running system
+ */
+
+#include "mkimage.h"
+#include "fit_common.h"
+#include <image.h>
+#include <u-boot/uuid.h>
+
+#define UUID_V4_VERSION_BYTE	6	/* offset of version nibble */
+#define UUID_V4_VARIANT_BYTE	8	/* offset of variant bits */
+
+#define SYSFS_UUID_PATH \
+	"/sys/firmware/devicetree/base/chosen/u-boot,fit-install-uuid"
+
+static void usage(const char *cmdname)
+{
+	fprintf(stderr,
+		"Usage: %s [options]\n"
+		"  -f <file>    FIT image file (or raw device for -g/-m)\n"
+		"  -u <uuid>    UUID string to stamp (optional; generates random if omitted)\n"
+		"  -g           Get mode: print existing UUID and exit\n"
+		"  -m           Match mode: compare UUID in file against running system\n"
+		"  -h           Show this help\n",
+		cmdname);
+	exit(EXIT_FAILURE);
+}
+
+/**
+ * gen_uuid_v4() - generate a random UUIDv4
+ * @uuid_bin: output buffer (16 bytes)
+ *
+ * Reads 16 random bytes from /dev/urandom and sets the version (4)
+ * and variant (RFC 4122) bits.
+ *
+ * Return: 0 on success, -1 on error
+ */
+static int gen_uuid_v4(unsigned char *uuid_bin)
+{
+	FILE *f;
+	size_t n;
+
+	f = fopen("/dev/urandom", "rb");
+	if (!f) {
+		fprintf(stderr, "Cannot open /dev/urandom: %s\n",
+			strerror(errno));
+		return -1;
+	}
+
+	n = fread(uuid_bin, 1, UUID_BIN_LEN, f);
+	fclose(f);
+
+	if (n != UUID_BIN_LEN) {
+		fprintf(stderr, "Short read from /dev/urandom\n");
+		return -1;
+	}
+
+	/* Set version 4 (bits 12-15 of time_hi_and_version) */
+	uuid_bin[UUID_V4_VERSION_BYTE] &= 0x0f;
+	uuid_bin[UUID_V4_VERSION_BYTE] |= 0x40;
+
+	/* Set variant to RFC 4122 (10xx xxxx) */
+	uuid_bin[UUID_V4_VARIANT_BYTE] &= 0x3f;
+	uuid_bin[UUID_V4_VARIANT_BYTE] |= 0x80;
+
+	return 0;
+}
+
+/**
+ * read_fit_uuid() - extract the install-uuid from a FIT file/device
+ * @fname:    path to FIT image file or raw device
+ * @uuid_bin: output buffer (must be at least FIT_INSTALL_UUID_LEN bytes)
+ *
+ * Opens the file, validates the FDT header, and copies the raw
+ * install-uuid bytes into @uuid_bin.
+ *
+ * Return: 0 on success, -1 on error
+ */
+static int read_fit_uuid(const char *fname, unsigned char *uuid_bin)
+{
+	struct fdt_header hdr;
+	const void *uuid;
+	uint32_t totalsize;
+	void *buf;
+	int is_mmap = 0;
+	ssize_t n;
+	int len, fd;
+
+	fd = open(fname, O_RDONLY);
+	if (fd < 0) {
+		fprintf(stderr, "Cannot open %s: %s\n", fname,
+			strerror(errno));
+		return -1;
+	}
+
+	n = read(fd, &hdr, sizeof(hdr));
+	if (n < (ssize_t)sizeof(hdr)) {
+		fprintf(stderr, "%s: too short to be a FIT\n", fname);
+		close(fd);
+		return -1;
+	}
+
+	if (fdt_check_header(&hdr)) {
+		fprintf(stderr, "%s: bad FDT header\n", fname);
+		close(fd);
+		return -1;
+	}
+
+	totalsize = fdt_totalsize(&hdr);
+
+	/* Try mmap first (works for files and block devices) */
+	buf = mmap(NULL, totalsize, PROT_READ, MAP_PRIVATE, fd, 0);
+	if (buf != MAP_FAILED) {
+		is_mmap = 1;
+	} else {
+		/* Fall back to read for character devices (e.g. UBI volumes) */
+		buf = malloc(totalsize);
+		if (!buf) {
+			fprintf(stderr, "Out of memory (%u bytes)\n",
+				totalsize);
+			close(fd);
+			return -1;
+		}
+		memcpy(buf, &hdr, sizeof(hdr));
+		n = read(fd, (char *)buf + sizeof(hdr),
+			 totalsize - sizeof(hdr));
+		if (n < (ssize_t)(totalsize - sizeof(hdr))) {
+			fprintf(stderr, "%s: short read\n", fname);
+			free(buf);
+			close(fd);
+			return -1;
+		}
+	}
+	close(fd);
+
+	uuid = fdt_getprop(buf, 0, FIT_INSTALL_UUID_PROP, &len);
+	if (!uuid || len != FIT_INSTALL_UUID_LEN) {
+		fprintf(stderr, "%s: no valid install-uuid property\n", fname);
+		if (is_mmap)
+			munmap(buf, totalsize);
+		else
+			free(buf);
+		return -1;
+	}
+
+	memcpy(uuid_bin, uuid, FIT_INSTALL_UUID_LEN);
+
+	if (is_mmap)
+		munmap(buf, totalsize);
+	else
+		free(buf);
+
+	return 0;
+}
+
+/**
+ * do_get_uuid() - read and print the install-uuid from a FIT file/device
+ * @fname: path to FIT image file or raw device
+ *
+ * Reads the install-uuid and prints it as a UUID string to stdout.
+ *
+ * Return: EXIT_SUCCESS or EXIT_FAILURE
+ */
+static int do_get_uuid(const char *fname)
+{
+	unsigned char uuid_bin[FIT_INSTALL_UUID_LEN];
+	char uuid_str[UUID_STR_LEN + 1];
+
+	if (read_fit_uuid(fname, uuid_bin))
+		return EXIT_FAILURE;
+
+	uuid_bin_to_str(uuid_bin, uuid_str, UUID_STR_FORMAT_STD);
+	printf("%s\n", uuid_str);
+
+	return EXIT_SUCCESS;
+}
+
+/**
+ * do_match_uuid() - match install-uuid in a FIT against the running system
+ * @fname: path to FIT image file or raw device
+ *
+ * Reads the install-uuid from the given FIT file and compares it
+ * against the raw bytes in the sysfs node exposed by the running
+ * U-Boot (via the chosen node in the device-tree).
+ *
+ * Return: EXIT_SUCCESS if UUIDs match, EXIT_FAILURE otherwise
+ */
+static int do_match_uuid(const char *fname)
+{
+	unsigned char fit_uuid[FIT_INSTALL_UUID_LEN];
+	unsigned char sys_uuid[FIT_INSTALL_UUID_LEN];
+	char fit_str[UUID_STR_LEN + 1];
+	char sys_str[UUID_STR_LEN + 1];
+	FILE *f;
+	size_t n;
+
+	if (read_fit_uuid(fname, fit_uuid))
+		return EXIT_FAILURE;
+
+	f = fopen(SYSFS_UUID_PATH, "rb");
+	if (!f) {
+		fprintf(stderr, "Cannot open %s: %s\n", SYSFS_UUID_PATH,
+			strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	n = fread(sys_uuid, 1, FIT_INSTALL_UUID_LEN, f);
+	fclose(f);
+
+	if (n != FIT_INSTALL_UUID_LEN) {
+		fprintf(stderr, "Short read from %s (got %zu, expected %d)\n",
+			SYSFS_UUID_PATH, n, FIT_INSTALL_UUID_LEN);
+		return EXIT_FAILURE;
+	}
+
+	if (memcmp(fit_uuid, sys_uuid, FIT_INSTALL_UUID_LEN) == 0) {
+		uuid_bin_to_str(fit_uuid, fit_str, UUID_STR_FORMAT_STD);
+		printf("%s\n", fit_str);
+		return EXIT_SUCCESS;
+	}
+
+	uuid_bin_to_str(fit_uuid, fit_str, UUID_STR_FORMAT_STD);
+	uuid_bin_to_str(sys_uuid, sys_str, UUID_STR_FORMAT_STD);
+	fprintf(stderr, "UUID mismatch: file=%s system=%s\n",
+		fit_str, sys_str);
+
+	return EXIT_FAILURE;
+}
+
+/**
+ * do_set_uuid() - stamp an install-uuid into a FIT image file
+ * @fname:    path to FIT image file
+ * @uuid_arg: UUID string to write, or NULL to generate a random one
+ *
+ * Opens the FIT file via mmap, generates or parses the UUID, and writes
+ * it into the install-uuid property.  If the property already exists with
+ * the correct size (16 bytes), uses fdt_setprop_inplace(); otherwise
+ * uses fdt_setprop() which may grow the FDT.
+ *
+ * Return: EXIT_SUCCESS or EXIT_FAILURE
+ */
+static int do_set_uuid(const char *cmdname, const char *fname,
+		       const char *uuid_arg)
+{
+	unsigned char uuid_bin[UUID_BIN_LEN];
+	char uuid_str[UUID_STR_LEN + 1];
+	struct stat fsbuf;
+	void *fit_blob;
+	const void *prop;
+	int ffd, len, ret;
+
+	ffd = mmap_fdt(cmdname, fname, FIT_INSTALL_UUID_LEN + 256,
+		       &fit_blob, &fsbuf, false, false);
+	if (ffd < 0) {
+		fprintf(stderr, "Could not open %s\n", fname);
+		return EXIT_FAILURE;
+	}
+
+	/* Generate or parse UUID */
+	if (uuid_arg) {
+		ret = uuid_str_to_bin(uuid_arg, uuid_bin, UUID_STR_FORMAT_STD);
+		if (ret) {
+			fprintf(stderr, "Invalid UUID string: %s\n", uuid_arg);
+			goto err;
+		}
+	} else {
+		if (gen_uuid_v4(uuid_bin)) {
+			fprintf(stderr, "Failed to generate UUID\n");
+			goto err;
+		}
+	}
+
+	/* Write UUID into FIT */
+	prop = fdt_getprop(fit_blob, 0, FIT_INSTALL_UUID_PROP, &len);
+	if (prop && len == FIT_INSTALL_UUID_LEN) {
+		ret = fdt_setprop_inplace(fit_blob, 0, FIT_INSTALL_UUID_PROP,
+					  uuid_bin, FIT_INSTALL_UUID_LEN);
+	} else {
+		ret = fdt_setprop(fit_blob, 0, FIT_INSTALL_UUID_PROP,
+				  uuid_bin, FIT_INSTALL_UUID_LEN);
+	}
+
+	if (ret) {
+		fprintf(stderr, "Failed to set install-uuid: %s\n",
+			fdt_strerror(ret));
+		goto err;
+	}
+
+	uuid_bin_to_str(uuid_bin, uuid_str, UUID_STR_FORMAT_STD);
+	printf("%s\n", uuid_str);
+
+	munmap(fit_blob, fsbuf.st_size + FIT_INSTALL_UUID_LEN + 256);
+	close(ffd);
+	return EXIT_SUCCESS;
+
+err:
+	munmap(fit_blob, fsbuf.st_size + FIT_INSTALL_UUID_LEN + 256);
+	close(ffd);
+	return EXIT_FAILURE;
+}
+
+int main(int argc, char **argv)
+{
+	const char *fname = NULL;
+	const char *uuid_arg = NULL;
+	int get_mode = 0;
+	int match_mode = 0;
+	int c;
+
+	while ((c = getopt(argc, argv, "f:u:gmh")) != -1) {
+		switch (c) {
+		case 'f':
+			fname = optarg;
+			break;
+		case 'u':
+			uuid_arg = optarg;
+			break;
+		case 'g':
+			get_mode = 1;
+			break;
+		case 'm':
+			match_mode = 1;
+			break;
+		case 'h':
+		default:
+			usage(argv[0]);
+		}
+	}
+
+	if (!fname) {
+		fprintf(stderr, "%s: -f <file> is required\n", argv[0]);
+		usage(argv[0]);
+	}
+
+	if (match_mode)
+		return do_match_uuid(fname);
+
+	if (get_mode)
+		return do_get_uuid(fname);
+
+	return do_set_uuid(argv[0], fname, uuid_arg);
+}


### PR DESCRIPTION
OpenWrt has been using a bunch of downstream patches to allow the currently running Linux system to get a clue from where it has been loaded from. The convention currently is to define a phandle `/chosen/rootdisk` which points to the storage location (MTD partition, UBI volume or a partition on a block device). This approach has multiple issues:
1. DT representation of GPT partitions is a downstream hack which is unlikely to be accepted in upstream Linux.
2. Not all storage devices even have a DT representation at all (think: namespace of an NVMe, removable USB pendrive)
3. Identifying a storage location by topology might be the most accurate and formally correct way, but it's often very complex and error prone (think: U-Boot DT may not match Linux DT, for example)

Hence a better way to allow the running system to detect where it was started from is needed. As Linux often uses a PARTUUID or filesystem UUID to identify the rootfs, an approach similar to that but identifying a FIT rather than a block partition or filesystem would be much less complex, robust and generic (ie. possible across all types of storage devices).

This series implements a host tool as well as a U-Boot cmdline command to stamp a unique `install-uuid` into a FIT, and pass that UUID down to the OS as `/chosen/u-boot,fit-install-uuid`.

See also https://github.com/open-source-firmware/flat-image-tree/pull/40