### PR TITLE
arm: dts: agilex5: Set DTB filename and kernel node removal for non-secure boot

### DIFF
--- a/arch/arm/dts/socfpga_agilex5_socdk-u-boot.dtsi
+++ b/arch/arm/dts/socfpga_agilex5_socdk-u-boot.dtsi
@@ -217,3 +217,13 @@
 		};
 	};
 };
+
+#if !defined(CONFIG_SOCFPGA_SECURE_VAB_AUTH)
+&fdt_0_blob {
+	filename = "arch/arm/dts/socfpga_agilex5_socdk.dtb";
+};
+
+&binman {
+	/delete-node/ kernel;
+};
+#endif


### PR DESCRIPTION
Not Intended to checkin, just to trigger pipeline test 

--- 

Set the DTB filename in fdt_0_blob node and remove kernel node from binman node for non-secure boot scenarios.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
