### PR TITLE
spi: dw: Allow bits_per_word to be configured by device drivers

### DIFF
--- a/drivers/spi/designware_spi.c
+++ b/drivers/spi/designware_spi.c
@@ -497,12 +497,24 @@ static int dw_spi_xfer(struct udevice *dev, unsigned int bitlen,
 {
 	struct udevice *bus = dev->parent;
 	struct dw_spi_priv *priv = dev_get_priv(bus);
+	struct spi_slave *slave = dev_get_parent_priv(dev);
 	const u8 *tx = dout;
 	u8 *rx = din;
 	int ret = 0;
 	u32 cr0 = 0;
 	u32 val;
 	u32 cs;
+
+	/* Get bits_per_word from slave (set by device driver) */
+	if (slave->bits_per_word >= 4 && slave->bits_per_word <= priv->max_xfer) {
+		priv->bits_per_word = slave->bits_per_word;
+	} else if (slave->bits_per_word == 0) {
+		priv->bits_per_word = 8;  /* Default if not set */
+	} else {
+		dev_warn(dev, "Invalid bits_per_word %u, using 8\n",
+			 slave->bits_per_word);
+		priv->bits_per_word = 8;
+	}
 
 	/* spi core configured to do 8 bit transfers */
 	if (bitlen % 8) {

--- a/include/spi.h
+++ b/include/spi.h
@@ -159,6 +159,7 @@ struct spi_slave {
 	unsigned int max_write_size;
 	void *memory_map;
 
+	u8 bits_per_word;
 	u8 flags;
 #define SPI_XFER_BEGIN		BIT(0)	/* Assert CS before transfer */
 #define SPI_XFER_END		BIT(1)	/* Deassert CS after transfer */


### PR DESCRIPTION
Not Intended to checkin, just to trigger pipeline test

------

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
