### PR TITLE
configs: socfpga: Add QSPI support for Cyclone 5

### DIFF
--- a/include/configs/socfpga_common.h
+++ b/include/configs/socfpga_common.h
@@ -137,10 +137,27 @@
 #define BOOT_TARGET_DEVICES_MMC(func)
 #endif
 
+#ifdef CONFIG_CMD_SF
+#define BOOT_TARGET_DEVICES_QSPI(func) func(QSPI, qspi, na)
+#else
+#define BOOT_TARGET_DEVICES_QSPI(func)
+#endif
+
+#define BOOTENV_DEV_QSPI(devtypeu, devtypel, instance) \
+	"bootcmd_qspi=run qspiload; run qspiboot\0"
+
+#define BOOTENV_DEV_NAME_QSPI(devtypeu, devtypel, instance) \
+	"qspi "
+
 #define BOOT_TARGET_DEVICES(func) \
 	BOOT_TARGET_DEVICES_MMC(func) \
+	BOOT_TARGET_DEVICES_QSPI(func) \
 	BOOT_TARGET_DEVICES_PXE(func) \
 	BOOT_TARGET_DEVICES_DHCP(func)
+
+#ifndef SOCFPGA_BOOT_SETTINGS
+#define SOCFPGA_BOOT_SETTINGS
+#endif
 
 #include <config_distro_bootcmd.h>
 
@@ -154,6 +171,7 @@
 	"pxefile_addr_r=0x02200000\0" \
 	"ramdisk_addr_r=0x02300000\0" \
 	"socfpga_legacy_reset_compat=1\0" \
+	SOCFPGA_BOOT_SETTINGS \
 	BOOTENV
 
 #endif

--- a/include/configs/socfpga_cyclone5_socdk.h
+++ b/include/configs/socfpga_cyclone5_socdk.h
@@ -10,6 +10,24 @@
 /* Memory configurations */
 #define PHYS_SDRAM_1_SIZE		0x40000000	/* 1GiB on SoCDK */
 
+/* QSPI boot */
+#define FDT_SIZE		__stringify(0x00010000)
+#define KERNEL_SIZE		__stringify(0x005d0000)
+#define QSPI_FDT_ADDR		__stringify(0x00220000)
+#define QSPI_KERNEL_ADDR	__stringify(0x00230000)
+
+#define SOCFPGA_BOOT_SETTINGS \
+	"fdt_size=" FDT_SIZE "\0" \
+	"kernel_size=" KERNEL_SIZE "\0" \
+	"qspi_fdt_addr=" QSPI_FDT_ADDR "\0" \
+	"qspi_kernel_addr=" QSPI_KERNEL_ADDR "\0" \
+	"qspiboot=setenv bootargs earlycon " \
+		"root=/dev/mtdblock1 rw rootfstype=jffs2; " \
+		"bootz ${kernel_addr_r} - ${fdt_addr_r}\0" \
+	"qspiload=sf probe; " \
+		"sf read ${kernel_addr_r} ${qspi_kernel_addr} ${kernel_size}; " \
+		"sf read ${fdt_addr_r} ${qspi_fdt_addr} ${fdt_size}\0"
+
 /* The rest of the configuration is shared */
 #include <configs/socfpga_common.h>
 


### PR DESCRIPTION
Create PR to trigger pipeline test, not intended to checkin
----
Add QSPI boot support to boot target devices list. Platform can provide their own boot settings through OCFPGA_BOOT_SETTINGS macro if needed.

Add SOCFPGA_BOOT_SETTINGS for Cyclone 5.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
