### PR TITLE
video: video_bmp: fix out-of-bounds write in RLE8 decoder

### DIFF
--- a/drivers/video/video_bmp.c
+++ b/drivers/video/video_bmp.c
@@ -152,6 +152,8 @@ static void video_display_rle8_bitmap(struct udevice *dev,
 				y--;
 				fb -= width * bytes_per_pixel +
 					priv->line_length;
+				if (y < 0)
+					decode = 0;
 				break;
 			case BMP_RLE8_EOBMP:
 				/* end of bitmap */
@@ -165,12 +167,14 @@ static void video_display_rle8_bitmap(struct udevice *dev,
 					(y + y_off - 1) * priv->line_length +
 					(x + x_off) * bytes_per_pixel);
 				bmap += 4;
+				if (x >= width || y < 0)
+					decode = 0;
 				break;
 			default:
 				/* unencoded run */
 				runlen = bmap[1];
 				bmap += 2;
-				if (y < height) {
+				if (y >= 0 && y < height) {
 					if (x < width) {
 						if (x + runlen > width)
 							cnt = width - x;
@@ -188,7 +192,7 @@ static void video_display_rle8_bitmap(struct udevice *dev,
 			}
 		} else {
 			/* encoded run */
-			if (y < height) {
+			if (y >= 0 && y < height) {
 				runlen = bmap[0];
 				if (x < width) {
 					/* aggregate the same code */


### PR DESCRIPTION
## Summary

- Fix an out-of-bounds write vulnerability in the BMP RLE8 decoder that allows arbitrary memory writes via a crafted BMP file
- The [DELTA escape handler](https://github.com/u-boot/u-boot/blob/master/drivers/video/video_bmp.c#L160-L168) and [EOL handler](https://github.com/u-boot/u-boot/blob/master/drivers/video/video_bmp.c#L148-L155) in [`video_display_rle8_bitmap()`](https://github.com/u-boot/u-boot/blob/master/drivers/video/video_bmp.c#L126-L214) adjust `y` and the framebuffer pointer without bounds checking
- Both the [encoded run](https://github.com/u-boot/u-boot/blob/master/drivers/video/video_bmp.c#L191) and [unencoded run](https://github.com/u-boot/u-boot/blob/master/drivers/video/video_bmp.c#L173) paths fail to reject negative `y` values produced by these escapes

## Detail

`y` starts at `height - 1` and decrements. The RLE8 DELTA escape (`0x00 0x02 dx dy`) [subtracts `dy` from `y`](https://github.com/u-boot/u-boot/blob/master/drivers/video/video_bmp.c#L163) with no validation, and the EOL handler [decrements `y`](https://github.com/u-boot/u-boot/blob/master/drivers/video/video_bmp.c#L152) unconditionally. Either can drive `y` negative. The existing bounds checks on [encoded runs (`y < height`)](https://github.com/u-boot/u-boot/blob/master/drivers/video/video_bmp.c#L191) and [unencoded runs (`y < height`)](https://github.com/u-boot/u-boot/blob/master/drivers/video/video_bmp.c#L173) both pass for negative `y` because the comparisons are signed, so the decoder continues writing through an underflowed framebuffer pointer.

This patch adds bounds checks to the DELTA and EOL handlers to stop decoding when `y` goes negative, and adds a lower-bound check for `y` on both run-type code paths.

The same bug exists independently in the Rockchip U-Boot fork's `drivers/video/drm/bmp_helper.c`, where a fix has been submitted as [rockchip-linux/u-boot#100](https://github.com/rockchip-linux/u-boot/pull/100).