### PR TITLE
lib: fdtdec: validate bloblist FDT before consuming libfdt size

### DIFF
--- a/lib/fdtdec.c
+++ b/lib/fdtdec.c
@@ -1729,19 +1729,38 @@ static int fdtdec_match_dto_compatible(const void *base, const void *dto)
 	return 0;
 }
 
+static inline int fdtdec_ret_to_errno(int ret)
+{
+	switch (ret) {
+	case -FDT_ERR_NOTFOUND:
+		return -ENOENT;
+	case -FDT_ERR_EXISTS:
+		return -EEXIST;
+	case -FDT_ERR_NOSPACE:
+	case -FDT_ERR_NOPHANDLES:
+		return -ENOSPC;
+	default:
+		return -EINVAL;
+	}
+}
+
 static int fdtdec_apply_dto_blob(void **blob, __maybe_unused int size)
 {
 	int ret;
 
 	ret = fdt_check_header(*blob);
 	if (ret)
-		return ret;
+		return fdtdec_ret_to_errno(ret);
 
 	ret = fdtdec_match_dto_compatible(gd->fdt_blob, *blob);
 	if (ret)
 		return ret;
 
-	return fdt_overlay_apply_verbose((void *)gd->fdt_blob, *blob);
+	ret = fdt_overlay_apply_verbose((void *)gd->fdt_blob, *blob);
+	if (ret)
+		return fdtdec_ret_to_errno(ret);
+
+	return 0;
 }
 
 static int fdtdec_apply_bloblist_dtos(void)
@@ -1760,6 +1779,10 @@ static int fdtdec_apply_bloblist_dtos(void)
 	if (live_fdt != gd->fdt_blob)
 		return -ENOENT;
 
+	ret = fdt_check_full(live_fdt, blob_size);
+	if (ret)
+		return fdtdec_ret_to_errno(ret);
+
 	/* Calculate the allowed padded size */
 	padded_size = fdt_totalsize(live_fdt) + CONFIG_SYS_FDT_PAD;
 	max_size = bloblist_get_total_size() - bloblist_get_size() + blob_size;
@@ -1772,20 +1795,25 @@ static int fdtdec_apply_bloblist_dtos(void)
 		if (ret)
 			return ret;
 
+		blob_size = padded_size;
 		ret = fdt_open_into(live_fdt, live_fdt, padded_size);
 		if (ret)
-			return ret;
+			return fdtdec_ret_to_errno(ret);
 	}
 
 	ret = bloblist_apply_blobs(BLOBLISTT_FDT_OVERLAY, fdtdec_apply_dto_blob);
 	if (ret)
 		return ret;
 
-	/* Shrink the blob to the actual FDT size */
+	ret = fdt_check_full(live_fdt, blob_size);
+	if (ret)
+		return fdtdec_ret_to_errno(ret);
+
 	ret = fdt_pack(live_fdt);
 	if (ret)
-		return ret;
+		return fdtdec_ret_to_errno(ret);
 
+	/* Shrink the blob to the actual FDT size */
 	return bloblist_resize(BLOBLISTT_CONTROL_FDT, fdt_totalsize(live_fdt));
 }
 


### PR DESCRIPTION
Coverity Scan defects are observed in fdtdec_apply_bloblist_dtos(), since the live FDT taken from the bloblist is passed to libfdt helpers which consume header size/offset fields:
- fdt_open_into()
- fdt_pack()
- bloblist_resize(..., fdt_totalsize(...))

Add a small helper to validate the FDT header and confirm that the advertised totalsize fits within the currently allocated bloblist record. Use the sanitized size before calling fdt_open_into(), again after overlays are applied before calling fdt_pack(), and once more after packing before shrinking the bloblist record.

This keeps the existing flow unchanged while making the size consumers operate on validated FDT metadata.

Fixes: b70cbbfbf94f ("fdtdec: apply DT overlays from bloblist")
Addresses-Coverity-ID: CID 645837: (TAINTED_SCALAR)

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
