### PR TITLE
drivers: clk: n5x: update comment to describe PLL bypass

### DIFF
--- a/drivers/clk/altera/clk-mem-n5x.c
+++ b/drivers/clk/altera/clk-mem-n5x.c
@@ -58,7 +58,10 @@ static void clk_mem_basic_init(struct udevice *dev,
 	/* Put PLLs in bypass */
 	clk_mem_write_bypass_mempll(plat, MEMCLKMGR_BYPASS_MEMPLL_ALL);
 
-	/* Put PLLs in Reset */
+	/*
+	 * Put PLL in bypass which powers down the PLL
+	 * and bypasses it such that PLLOUT tracks REF.
+	 */
 	CM_REG_SETBITS(plat, MEMCLKMGR_MEMPLL_PLLCTRL,
 		       MEMCLKMGR_PLLCTRL_BYPASS_MASK);
 
@@ -68,7 +71,7 @@ static void clk_mem_basic_init(struct udevice *dev,
 	CM_REG_WRITEL(plat, cfg->mem_plldiv, MEMCLKMGR_MEMPLL_PLLDIV);
 	CM_REG_WRITEL(plat, cfg->mem_plloutdiv, MEMCLKMGR_MEMPLL_PLLOUTDIV);
 
-	/* Take PLL out of reset and power up */
+	/* Take PLL out of bypass */
 	CM_REG_CLRBITS(plat, MEMCLKMGR_MEMPLL_PLLCTRL,
 		       MEMCLKMGR_PLLCTRL_BYPASS_MASK);
 }

--- a/drivers/clk/altera/clk-n5x.c
+++ b/drivers/clk/altera/clk-n5x.c
@@ -63,7 +63,10 @@ static void clk_basic_init(struct udevice *dev,
 	clk_write_bypass_mainpll(plat, CLKMGR_BYPASS_MAINPLL_ALL);
 	clk_write_bypass_perpll(plat, CLKMGR_BYPASS_PERPLL_ALL);
 
-	/* Put both PLLs in Reset */
+	/*
+	 * Put both PLLs in bypass which power down the PLLs
+	 * and bypasses it such that PLLOUT tracks REF.
+	 */
 	CM_REG_SETBITS(plat, CLKMGR_MAINPLL_PLLCTRL,
 		       CLKMGR_PLLCTRL_BYPASS_MASK);
 	CM_REG_SETBITS(plat, CLKMGR_PERPLL_PLLCTRL,
@@ -84,7 +87,7 @@ static void clk_basic_init(struct udevice *dev,
 	CM_REG_WRITEL(plat, cfg->per_pll_emacctl, CLKMGR_PERPLL_EMACCTL);
 	CM_REG_WRITEL(plat, cfg->per_pll_gpiodiv, CLKMGR_PERPLL_GPIODIV);
 
-	/* Take both PLL out of reset and power up */
+	/* Take both PLLs out of bypass */
 	CM_REG_CLRBITS(plat, CLKMGR_MAINPLL_PLLCTRL,
 		       CLKMGR_PLLCTRL_BYPASS_MASK);
 	CM_REG_CLRBITS(plat, CLKMGR_PERPLL_PLLCTRL,


### PR DESCRIPTION
The existing comments incorrectly say "Put PLLs in Reset" and "Take PLL out of reset and power up", but the code actually toggles the PLL bypass bit. Update the comments to accurately describe the PLL bypass behavior.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.

CI Pipeline Test