### PR TITLE
[CI] treewide: Kconfig: use bool instead of tristate

### DIFF
--- a/board/st/common/Kconfig
+++ b/board/st/common/Kconfig
@@ -14,7 +14,7 @@ config DFU_ALT_RAM0
 	  This defines the partitions of ram used to build dfu dynamically.
 
 config TYPEC_STUSB160X
-	tristate "STMicroelectronics STUSB160X Type-C controller driver"
+	bool "STMicroelectronics STUSB160X Type-C controller driver"
 	depends on DM_I2C
 	help
 	  Say Y if your system has STMicroelectronics STUSB160X Type-C port

--- a/cmd/Kconfig
+++ b/cmd/Kconfig
@@ -3177,7 +3177,7 @@ config CMD_STACKPROTECTOR_TEST
 endmenu
 
 config CMD_UBI
-	tristate "Enable UBI - Unsorted block images commands"
+	bool "Enable UBI - Unsorted block images commands"
 	select MTD_UBI
 	help
 	  UBI is a software layer above MTD layer which admits use of LVM-like
@@ -3197,7 +3197,7 @@ config CMD_UBI_RENAME
 	   ubi rename <oldname> <newname>
 
 config CMD_UBIFS
-	tristate "Enable UBIFS - Unsorted block images filesystem commands"
+	bool "Enable UBIFS - Unsorted block images filesystem commands"
 	depends on CMD_UBI
 	default y if CMD_UBI
 	select LZO

--- a/drivers/cache/Kconfig
+++ b/drivers/cache/Kconfig
@@ -14,7 +14,7 @@ config CACHE
 	  configuring settings that be found from a device tree file.
 
 config L2X0_CACHE
-	tristate "PL310 cache driver"
+	bool "PL310 cache driver"
 	select CACHE
 	depends on ARM
 	help

--- a/drivers/clk/Kconfig
+++ b/drivers/clk/Kconfig
@@ -216,7 +216,7 @@ config CLK_HSDK
 	  Synopsys ARC HSDK-4xD boards
 
 config CLK_VERSACLOCK
-	tristate "Enable VersaClock 5/6 devices"
+	bool "Enable VersaClock 5/6 devices"
 	depends on CLK
 	depends on CLK_CCF
 	depends on OF_CONTROL

--- a/drivers/firmware/Kconfig
+++ b/drivers/firmware/Kconfig
@@ -14,7 +14,7 @@ config ARM_PSCI_FW
 	select FIRMWARE
 
 config TI_SCI_PROTOCOL
-	tristate "TI System Control Interface (TISCI) Message Protocol"
+	bool "TI System Control Interface (TISCI) Message Protocol"
 	depends on K3_SEC_PROXY
 	select DEVRES
 	select FIRMWARE

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -98,7 +98,7 @@ config SYS_I2C_EARLY_INIT
 	  board_early_init_f.
 
 config I2C_CROS_EC_TUNNEL
-	tristate "Chrome OS EC tunnel I2C bus"
+	bool "Chrome OS EC tunnel I2C bus"
 	depends on CROS_EC
 	help
 	  This provides an I2C bus that will tunnel i2c commands through to
@@ -213,14 +213,14 @@ config SYS_FSL_I2C4_OFFSET
 endif
 
 config SYS_I2C_CADENCE
-	tristate "Cadence I2C Controller"
+	bool "Cadence I2C Controller"
 	depends on DM_I2C
 	help
 	  Say yes here to select Cadence I2C Host Controller. This controller is
 	  e.g. used by Xilinx Zynq.
 
 config SYS_I2C_CA
-	tristate "Cortina-Access I2C Controller"
+	bool "Cortina-Access I2C Controller"
 	depends on DM_I2C && CORTINA_PLATFORM
 	help
 	  Add support for the Cortina Access I2C host controller.

--- a/drivers/i2c/muxes/Kconfig
+++ b/drivers/i2c/muxes/Kconfig
@@ -26,14 +26,14 @@ config I2C_ARB_GPIO_CHALLENGE
 	  a GPIO.
 
 config I2C_MUX_PCA9541
-	tristate "NXP PCA9541 I2C Master Selector"
+	bool "NXP PCA9541 I2C Master Selector"
 	depends on I2C_MUX
 	help
 	  If you say yes here you get support for the NXP PCA9541
 	  I2C Master Selector.
 
 config I2C_MUX_PCA954x
-	tristate "TI PCA954x I2C Mux/switches"
+	bool "TI PCA954x I2C Mux/switches"
 	depends on I2C_MUX
 	help
 	  If you say yes here you get support for the TI PCA954x I2C mux/switch
@@ -49,7 +49,7 @@ config I2C_MUX_PCA954x
 		MAX7356, MAX7357, MAX7358, MAX7367, MAX7368 and MAX7369
 
 config I2C_MUX_GPIO
-        tristate "GPIO-based I2C multiplexer"
+        bool "GPIO-based I2C multiplexer"
 	depends on I2C_MUX && DM_GPIO
 	select DEVRES
 	help

--- a/drivers/i3c/Kconfig
+++ b/drivers/i3c/Kconfig
@@ -1,5 +1,5 @@
 menuconfig I3C
-	tristate "I3C support"
+	bool "I3C support"
 	select I2C
 	select DEVRES
 	help

--- a/drivers/i3c/master/Kconfig
+++ b/drivers/i3c/master/Kconfig
@@ -1,5 +1,5 @@
 config DW_I3C_MASTER
-	tristate "Synopsys DesignWare I3C master driver"
+	bool "Synopsys DesignWare I3C master driver"
 	depends on I3C
 	help
 	  Support for Synopsys DesignWare MIPI I3C Controller.

--- a/drivers/memory/Kconfig
+++ b/drivers/memory/Kconfig
@@ -55,7 +55,7 @@ config STM32_OMM
 	    - the time between 2 transactions in multiplexed mode.
 
 config TI_AEMIF
-	tristate "Texas Instruments AEMIF driver"
+	bool "Texas Instruments AEMIF driver"
 	depends on ARCH_KEYSTONE || ARCH_DAVINCI
 	help
 	  This driver is for the AEMIF module available in Texas Instruments

--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -505,7 +505,7 @@ config TURRIS_OMNIA_MCU
 	  board power off.
 
 config USB_HUB_USB251XB
-	tristate "USB251XB Hub Controller Configuration Driver"
+	bool "USB251XB Hub Controller Configuration Driver"
 	depends on I2C
 	help
 	  This option enables support for configuration via SMBus of the

--- a/drivers/mmc/Kconfig
+++ b/drivers/mmc/Kconfig
@@ -576,7 +576,7 @@ config MMC_SDHCI_ATMEL
 	  specification.
 
 config MMC_SDHCI_BCM2835
-	tristate "SDHCI support for the BCM2835 SD/MMC Controller"
+	bool "SDHCI support for the BCM2835 SD/MMC Controller"
 	depends on ARCH_BCM283X
 	depends on MMC_SDHCI
 	select MMC_SDHCI_IO_ACCESSORS
@@ -589,7 +589,7 @@ config MMC_SDHCI_BCM2835
 	  If unsure, say N.
 
 config MMC_SDHCI_BCMSTB
-	tristate "SDHCI support for the BCMSTB SD/MMC Controller"
+	bool "SDHCI support for the BCMSTB SD/MMC Controller"
 	depends on MMC_SDHCI && (ARCH_BCMSTB || ARCH_BCM283X)
 	help
 	  This selects the Broadcom set-top box SD/MMC controller.

--- a/drivers/mtd/nand/Kconfig
+++ b/drivers/mtd/nand/Kconfig
@@ -1,5 +1,5 @@
 config MTD_NAND_CORE
-	tristate
+	bool
 
 source "drivers/mtd/nand/raw/Kconfig"
 

--- a/drivers/net/phy/Kconfig
+++ b/drivers/net/phy/Kconfig
@@ -233,7 +233,7 @@ config PHY_MICREL_KSZ8XXX
 endif # PHY_MICREL
 
 config PHY_MOTORCOMM
-	tristate "Motorcomm PHYs"
+	bool "Motorcomm PHYs"
 	help
 	  Enables support for Motorcomm network PHYs.
 	  Currently supports the YT8511 and YT8531 Gigabit Ethernet PHYs.
@@ -246,7 +246,7 @@ config PHY_NATSEMI
 	bool "National Semiconductor Ethernet PHYs support"
 
 config PHY_NXP_C45_TJA11XX
-	tristate "NXP C45 TJA11XX PHYs"
+	bool "NXP C45 TJA11XX PHYs"
 	select DEVRES
 	help
 	  Enable support for NXP C45 TJA11XX PHYs.

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -548,7 +548,7 @@ config SOFT_SPI
 	 the SPI protocol.
 
 config SPI_SN_F_OSPI
-	tristate "Socionext F_OSPI SPI flash controller"
+	bool "Socionext F_OSPI SPI flash controller"
 	select SPI_MEM
 	help
 	  This enables support for the Socionext F_OSPI controller

--- a/drivers/ufs/Kconfig
+++ b/drivers/ufs/Kconfig
@@ -24,7 +24,7 @@ config UFS_CADENCE
 	  controller present on present TI's J721e devices.
 
 config UFS_MEDIATEK
-	tristate "MediaTek UFS Host Controller Driver"
+	bool "MediaTek UFS Host Controller Driver"
 	depends on UFS && ARCH_MEDIATEK
 	select PHY_MTK_UFS
 	help

--- a/drivers/usb/cdns3/Kconfig
+++ b/drivers/usb/cdns3/Kconfig
@@ -1,5 +1,5 @@
 config USB_CDNS3
-	tristate "Cadence USB3 Dual-Role Controller"
+	bool "Cadence USB3 Dual-Role Controller"
 	depends on USB_XHCI_HCD || USB_GADGET
 	select DEVRES
 	help
@@ -51,14 +51,14 @@ config SPL_USB_CDNS3_HOST
 	  standard XHCI driver.
 
 config USB_CDNS3_STARFIVE
-	tristate "Cadence USB3 support on Starfive platforms"
+	bool "Cadence USB3 support on Starfive platforms"
 	default y if STARFIVE_JH7110
 	help
 	  Say 'Y' here if you are building for Starfive platforms
 	  that contain Cadence USB3 controller core. E.g.: JH7110.
 
 config USB_CDNS3_TI
-	tristate "Cadence USB3 support on TI platforms"
+	bool "Cadence USB3 support on TI platforms"
 	default USB_CDNS3
 	help
 	  Say 'Y' here if you are building for Texas Instruments

--- a/drivers/usb/musb-new/Kconfig
+++ b/drivers/usb/musb-new/Kconfig
@@ -48,7 +48,7 @@ config USB_MUSB_TI
 	  silicon IP.
 
 config USB_MUSB_OMAP2PLUS
-	tristate "OMAP2430 and onwards"
+	bool "OMAP2430 and onwards"
 	depends on ARCH_OMAP2PLUS
 
 config USB_MUSB_AM35X

--- a/drivers/usb/tcpm/Kconfig
+++ b/drivers/usb/tcpm/Kconfig
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: GPL-2.0
 
 config TYPEC_TCPM
-	tristate "USB Type-C Port Controller Manager"
+	bool "USB Type-C Port Controller Manager"
 	depends on DM
 	help
 	  The Type-C Port Controller Manager provides a USB PD and USB Type-C
 	  state machine for use with Type-C Port Controllers.
 
 config TYPEC_FUSB302
-	tristate "Fairchild FUSB302 Type-C chip driver"
+	bool "Fairchild FUSB302 Type-C chip driver"
 	depends on DM && DM_I2C && TYPEC_TCPM
 	help
 	  The Fairchild FUSB302 Type-C chip driver that works with


### PR DESCRIPTION
Dummy PR to trigger a CI run