### PR TITLE
arm: dts: socfpga: enforce MMC fifo-mode for high-memory access

### DIFF
--- a/arch/arm/dts/socfpga-common-u-boot.dtsi
+++ b/arch/arm/dts/socfpga-common-u-boot.dtsi
@@ -33,3 +33,7 @@
 &sysmgr {
 	bootph-all;
 };
+
+&mmc {
+	fifo-mode;
+};

--- a/arch/arm/dts/socfpga_agilex-u-boot.dtsi
+++ b/arch/arm/dts/socfpga_agilex-u-boot.dtsi
@@ -104,6 +104,7 @@
 
 &mmc {
 	resets = <&rst SDMMC_RESET>, <&rst SDMMC_OCP_RESET>;
+	fifo-mode;
 };
 
 &porta {

--- a/arch/arm/dts/socfpga_arria10-u-boot.dtsi
+++ b/arch/arm/dts/socfpga_arria10-u-boot.dtsi
@@ -53,6 +53,10 @@
 	altr,sysmgr-syscon = <&sysmgr 0x4C 0>;
 };
 
+&mmc {
+	fifo-mode;
+};
+
 &i2c0 {
 	reset-names = "i2c";
 };

--- a/arch/arm/dts/socfpga_arria10_chameleonv3.dtsi
+++ b/arch/arm/dts/socfpga_arria10_chameleonv3.dtsi
@@ -73,6 +73,7 @@
 };
 
 &mmc {
+	fifo-mode;
 	status = "okay";
 };
 

--- a/arch/arm/dts/socfpga_arria10_mercury_aa1.dtsi
+++ b/arch/arm/dts/socfpga_arria10_mercury_aa1.dtsi
@@ -65,6 +65,7 @@
 	cap-sd-highspeed;
 	broken-cd;
 	bus-width = <4>;
+	fifo-mode;
 };
 
 &osc1 {

--- a/arch/arm/dts/socfpga_n5x-u-boot.dtsi
+++ b/arch/arm/dts/socfpga_n5x-u-boot.dtsi
@@ -92,6 +92,7 @@
 	clocks = <&clkmgr N5X_L4_MP_CLK>,
 		 <&clkmgr N5X_SDMMC_CLK>;
 	resets = <&rst SDMMC_RESET>, <&rst SDMMC_OCP_RESET>;
+	fifo-mode;
 };
 
 &pdma {

--- a/arch/arm/dts/socfpga_stratix10-u-boot.dtsi
+++ b/arch/arm/dts/socfpga_stratix10-u-boot.dtsi
@@ -6,3 +6,7 @@
  */
 
 #include "socfpga_soc64_fit-u-boot.dtsi"
+
+&mmc {
+	fifo-mode;
+};


### PR DESCRIPTION
DMA-based MMC transfers are limited to a 32-bit address space and can fail when buffers are placed outside low memory. Enabling fifo-mode disables DMA and allows U-Boot to reliably access MMC data from both low and high DDR addresses using CPU-driven FIFO transfers.

This avoids future failures as the .wic image size has already reached the current threshold and is expected to grow further, requiring increased use of high-memory load addresses.

Applying this at the SoC DTSI level enforces consistent behavior across all SoCFPGA-based products that uses the dw-mmc driver and ensures reliable MMC access as image sizes increase and high-memory buffer usage becomes unavoidable.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
