### PR TITLE
net: dwc_eth_xgmac: Return -ENODEV when phy_connect() fails

### DIFF
--- a/drivers/net/dwc_eth_xgmac.c
+++ b/drivers/net/dwc_eth_xgmac.c
@@ -507,6 +507,7 @@ static int xgmac_start(struct udevice *dev)
 					 xgmac->config->interface(dev));
 		if (!xgmac->phy) {
 			pr_err("%s phy_connect() failed\n", dev->name);
+			ret = -ENODEV;
 			goto err_stop_resets;
 		}
 


### PR DESCRIPTION
[NOT INTENDED TO CHECK IN: Just to trigger pipeline test]
When multiple Ethernet controllers are enabled in the device tree, but only one controller is actually present in hardware, the non-existent controller still attempts to connect to a PHY.

In this case, phy_connect() may return NULL without setting an error code. The current driver only logs the failure but does not propagate an error, causing the initialization flow to continue with an invalid PHY handle.

This leads to failures later in the initialization sequence.

Fix this by explicitly setting ret = -ENODEV when phy_connect() returns NULL, ensuring the driver exits cleanly on failure.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
