### PR TITLE
x86: enable CONFIG_REMAKE_ELF builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1937,6 +1937,7 @@ u-boot-with-spl-pbl.bin: spl/u-boot-spl.pbl $(UBOOT_BINLOAD) FORCE
 quiet_cmd_u-boot-elf ?= LD      $@
 	cmd_u-boot-elf ?= $(LD) u-boot-elf.o -o $@ \
 	$(if $(CONFIG_SYS_BIG_ENDIAN),-EB,-EL) \
+	$(PLATFORM_ELFLDFLAGS) \
 	-T u-boot-elf.lds --defsym=$(CONFIG_PLATFORM_ELFENTRY)=$(CONFIG_TEXT_BASE) \
 	-Ttext=$(CONFIG_TEXT_BASE)
 u-boot.elf: u-boot.bin u-boot-elf.lds

--- a/arch/x86/config.mk
+++ b/arch/x86/config.mk
@@ -24,9 +24,13 @@ EFI_IS_32BIT :=
 endif
 
 ifeq ($(IS_32BIT),y)
-PLATFORM_CPPFLAGS += -march=i386 -m32
+PLATFORM_CPPFLAGS	+= -march=i386 -m32
+PLATFORM_ELFFLAGS	+= -O elf32-i386 -B i386
+PLATFORM_ELFLDFLAGS	+= -m elf_i386
 else
-PLATFORM_CPPFLAGS += $(if $(CONFIG_XPL_BUILD),,-fpic) -fno-common -march=core2 -m64
+PLATFORM_CPPFLAGS	+= $(if $(CONFIG_XPL_BUILD),,-fpic) -fno-common -march=core2 -m64
+PLATFORM_ELFFLAGS	+= -O elf64-x86-64 -B i386:x86-64
+PLATFORM_ELFLDFLAGS	+= -m elf_x86_64
 
 ifndef CONFIG_X86_HARDFP
 PLATFORM_CPPFLAGS += -mno-mmx -mno-sse


### PR DESCRIPTION
Fix objcopy/ld parameters for x86 to enable CONFIG_REMAKE_ELF builds.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
