### PR TITLE
arm: socfpga: Rename TARGET to ARCH for SoCFPGA

### DIFF
--- a/arch/arm/mach-socfpga/board.c
+++ b/arch/arm/mach-socfpga/board.c
@@ -210,8 +210,8 @@ void lmb_arch_add_memory(void)
 }
 #endif
 
-#if (defined(CONFIG_TARGET_SOCFPGA_ARRIA10) || \
-     defined(CONFIG_TARGET_SOCFPGA_GEN5)) && defined(CONFIG_XPL_BUILD)
+#if (defined(CONFIG_ARCH_SOCFPGA_ARRIA10) || \
+     defined(CONFIG_ARCH_SOCFPGA_GEN5)) && defined(CONFIG_XPL_BUILD)
 unsigned long board_spl_mmc_get_uboot_raw_sector(struct mmc *mmc,
 						 unsigned long raw_sect)
 {

--- a/cmd/Kconfig
+++ b/cmd/Kconfig
@@ -1911,7 +1911,7 @@ menu "Shell scripting commands"
 
 config CMD_C5_PL330_DMA
 	bool "Release Reset DMA Channels for PL330 Handshake"
-	depends on TARGET_SOCFPGA_CYCLONE5
+	depends on ARCH_SOCFPGA_CYCLONE5
 	help
 	  Provides access to Reset Manager Per2ModRst. Enables DMA
 	  channels for ARM PrimeCell PL330 via reset release.


### PR DESCRIPTION
Commit 62f7a9460209 ("Replace TARGET namespace and cleanup properly") replaces the TARGET namespace to ARCH for all SoCFPGA devices.

Some of the TARGET namespaces are still left out, update leftover TARGET to ARCH following current SoCFPGA naming.

Fixes: 62f7a9460209 ("Replace TARGET namespace and cleanup properly")

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
