### PR TITLE
reset: socfpga: add legacy peripheral reset compatibility Kconfig

### DIFF
--- a/board/keymile/secu1/socfpga_secu.env
+++ b/board/keymile/secu1/socfpga_secu.env
@@ -12,7 +12,6 @@ load=tftpboot ${loadaddr} u-boot-with-nand-spl.sfp
 loadaddr=CONFIG_KM_KERNEL_ADDR
 newenv=nand erase 0x100000 0x40000
 release=run newenv; reset
-socfpga_legacy_reset_compat=1
 update=nand erase 0x0 0x00100000 && nand write ${loadaddr} 0x0 ${filesize}
 
 userload=ubi part nand.ubi &&

--- a/drivers/reset/Kconfig
+++ b/drivers/reset/Kconfig
@@ -147,6 +147,18 @@ config RESET_SOCFPGA
 	help
 	  Support for reset controller on SoCFPGA platform.
 
+config SOCFPGA_RESET_LEGACY_COMPAT
+	bool "SoCFPGA legacy peripheral reset compatibility"
+	depends on RESET_SOCFPGA
+	default y
+	help
+	  When enabled, all peripheral resets are deasserted before booting
+	  into the OS. This is required for systems running Linux kernels that
+	  lack proper peripheral reset driver support (typically gen5 and
+	  Arria10 platforms, Stratix10, Agilex, Agilex5, Agilex7m, N5X).
+	  Disable for future platforms whose kernels have full peripheral
+	  reset driver support.
+
 config RESET_MEDIATEK
 	bool "Reset controller driver for MediaTek SoCs"
 	depends on DM_RESET && ARCH_MEDIATEK && CLK

--- a/drivers/reset/reset-socfpga.c
+++ b/drivers/reset/reset-socfpga.c
@@ -32,34 +32,43 @@ struct socfpga_reset_data {
 	void __iomem *modrst_base;
 };
 
-/*
- * For compatibility with Kernels that don't support peripheral reset, this
- * driver can keep the old behaviour of not asserting peripheral reset before
- * starting the OS and deasserting all peripheral resets (enabling all
- * peripherals).
+/**
+ * socfpga_reset_keep_enabled() - decide whether peripheral resets stay deasserted
  *
- * For that, the reset driver checks the environment variable
- * "socfpga_legacy_reset_compat". If this variable is '1', perihperals are not
- * reset again once taken out of reset and all peripherals in 'permodrst' are
- * taken out of reset before booting into the OS.
- * Note that this should be required for gen5 systems only that are running
- * Linux kernels without proper peripheral reset support for all drivers used.
+ * Returns true if the driver should deassert all peripheral resets before
+ * handing off to the OS (legacy behaviour required by kernels without full
+ * peripheral reset driver support, typically gen5 / Arria10).
+ *
+ * Decision priority:
+ *  1. If CONFIG_SOCFPGA_RESET_LEGACY_COMPAT is disabled at build time, always
+ *     return false (no bulk deassertion), regardless of the environment.
+ *  2. Otherwise, if the environment variable "socfpga_legacy_reset_compat" is
+ *     present and set to '1', return true; if set to any other value, return
+ *     false.
+ *  3. If the variable is absent, fall back to returning true (safe default for
+ *     platforms that have not yet opted out).
  */
 static bool socfpga_reset_keep_enabled(void)
 {
+	if (!IS_ENABLED(CONFIG_SOCFPGA_RESET_LEGACY_COMPAT))
+		return false;
+
 #if !defined(CONFIG_XPL_BUILD) || CONFIG_IS_ENABLED(ENV_SUPPORT)
-	const char *env_str;
+	const char *env_str = env_get("socfpga_legacy_reset_compat");
 	long val;
 
-	env_str = env_get("socfpga_legacy_reset_compat");
 	if (env_str) {
 		val = simple_strtol(env_str, NULL, 0);
-		if (val == 1)
-			return true;
+		return val == 1;
 	}
 #endif
 
-	return false;
+	/*
+	 * ENV_SUPPORT is absent in some SPL builds; dm_remove_devices_active()
+	 * is never called from SPL so this path is dead there. Default to true
+	 * to preserve legacy behaviour for U-Boot proper.
+	 */
+	return true;
 }
 
 static int socfpga_reset_assert(struct reset_ctl *reset_ctl)

--- a/include/configs/socfpga_common.h
+++ b/include/configs/socfpga_common.h
@@ -153,7 +153,6 @@
 	"scriptaddr=0x02100000\0" \
 	"pxefile_addr_r=0x02200000\0" \
 	"ramdisk_addr_r=0x02300000\0" \
-	"socfpga_legacy_reset_compat=1\0" \
 	BOOTENV
 
 #endif

--- a/include/configs/socfpga_dbm_soc1.h
+++ b/include/configs/socfpga_dbm_soc1.h
@@ -79,8 +79,7 @@
 			"echo Running bootscript... ; "			\
 			"source ${kernel_addr_r} ; "			\
 		"fi ; "							\
-		"fi\0"							\
-	"socfpga_legacy_reset_compat=1\0"
+		"fi\0"
 
 /* The rest of the configuration is shared */
 #include <configs/socfpga_common.h>

--- a/include/configs/socfpga_mcvevk.h
+++ b/include/configs/socfpga_mcvevk.h
@@ -21,7 +21,6 @@
 	"netdev=eth0\0"							\
 	"hostname=mcvevk\0"						\
 	"kernel_addr_r=0x10000000\0"					\
-	"socfpga_legacy_reset_compat=1\0"				\
 	"bootm_size=0xa000000\0"					\
 	"dfu_alt_info=mmc raw 0 3867148288\0"				\
 	"update_filename=u-boot-with-spl.sfp\0"				\

--- a/include/configs/socfpga_soc64_common.h
+++ b/include/configs/socfpga_soc64_common.h
@@ -144,7 +144,6 @@
 		" ${qspi_clock}; echo QSPI clock frequency updated; fi; fi\0" \
 	"scriptaddr=0x81000000\0" \
 	"scriptfile=boot.scr\0" \
-	"socfpga_legacy_reset_compat=1\0" \
 	"smc_fid_rd=0xC2000007\0" \
 	"smc_fid_wr=0xC2000008\0" \
 	"smc_fid_upd=0xC2000009\0 " \
@@ -177,7 +176,6 @@
 	"scriptaddr=0x05FF0000\0" \
 	"scriptfile=boot.scr\0" \
 	"nandroot=ubi0:rootfs\0" \
-	"socfpga_legacy_reset_compat=1\0" \
 	"smc_fid_rd=0xC2000007\0" \
 	"smc_fid_wr=0xC2000008\0" \
 	"smc_fid_upd=0xC2000009\0 " \
@@ -236,7 +234,6 @@
 			" root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; " \
 			"bootm ${loadaddr}\0" \
 	"nandfitload=ubi part root; ubi readvol ${loadaddr} kernel\0" \
-	"socfpga_legacy_reset_compat=1\0" \
 	"smc_fid_rd=0xC2000007\0" \
 	"smc_fid_wr=0xC2000008\0" \
 	"smc_fid_upd=0xC2000009\0 "

--- a/include/configs/socfpga_vining_fpga.h
+++ b/include/configs/socfpga_vining_fpga.h
@@ -181,8 +181,7 @@
 			"led 1 on ; "		/* Top RED */		\
 			"run ubi_ubi ; "				\
 		"else echo \"Unsupported boot mode: \"${bootmode} ; "	\
-		"fi\0"							\
-		"socfpga_legacy_reset_compat=1\0"
+		"fi\0"
 
 /* The rest of the configuration is shared */
 #include <configs/socfpga_common.h>


### PR DESCRIPTION
CI Pipeline Test

Introduce CONFIG_SOCFPGA_RESET_LEGACY_COMPAT to control whether all peripheral resets are deasserted before booting into the OS. This behaviour is only required for systems running Linux kernels that lack proper peripheral reset driver support.

Previously the decision was driven solely by the environment variable socfpga_legacy_reset_compat, which defaulted to 1 across all SoCFPGA targets. The new Kconfig option defaults to y for all ARCH_SOCFPGA targets to preserve existing behaviour, but allows individual platforms to opt out at compile time. When the option is disabled, the bulk deassertion is skipped unconditionally and the environment variable is ignored.

Since the Kconfig option is now the single source of truth, the hardcoded socfpga_legacy_reset_compat=1 default environment string is removed from SoCFPGA board configs and from the keymile secu1 board .env file. This is a no-op for boards that keep
CONFIG_SOCFPGA_RESET_LEGACY_COMPAT=y, since the driver falls back to true when the variable is absent, but removes a redundant source of truth and keeps the configuration consistent across platforms.

Runtime override via setenv remains functional for platforms with the option enabled.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
