### PR TITLE
arm: socfpga: spl: skip HPS SMMU secure config when node absent

### DIFF
--- a/arch/arm/mach-socfpga/spl_soc64.c
+++ b/arch/arm/mach-socfpga/spl_soc64.c
@@ -8,6 +8,7 @@
 #include <hang.h>
 #include <spl.h>
 #include <dm/uclass.h>
+#include <linux/errno.h>
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -136,7 +137,15 @@ void spl_perform_arch_fixups(struct spl_image_info *spl_image)
 	struct udevice *dev;
 
 	ret = uclass_get_device_by_name(UCLASS_NOP, "socfpga-smmu-secure-config", &dev);
-	if (ret) {
+	if (ret == -ENODEV) {
+		/*
+		 * No socfpga-smmu-secure-config node: nothing for U-Boot to
+		 * program (e.g. parts where ATF/BL31 owns the System-Manager
+		 * TBU stream-ID / secure-SID setup, or where the reset default
+		 * already suffices). Skip instead of failing.
+		 */
+		debug("HPS SMMU secure settings: no DT node, skipping\n");
+	} else if (ret) {
 		printf("HPS SMMU secure settings init failed: %d\n", ret);
 		hang();
 	}


### PR DESCRIPTION
CI Pipeline Test

spl_perform_arch_fixups() looks up the "socfpga-smmu-secure-config" node by name and calls hang() on any error, so every SoC64 platform is forced to carry the node even when it has nothing to program.

Treat a missing node (-ENODEV) as "nothing to do" and skip it, while still calling hang() on a genuine probe/dtreg failure when the node is present. This lets parts where the System-Manager TBU stream-ID / secure-SID setup is owned elsewhere (e.g. by ATF/BL31), or where the reset default already suffices, omit the node without hanging. Legacy SoC64 parts that still program it from U-Boot keep the existing error detection.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
