### PR TITLE
arm: socfpga: misc: Resolve sysmgr via DM when alias is missing

### DIFF
--- a/arch/arm/mach-socfpga/misc.c
+++ b/arch/arm/mach-socfpga/misc.c
@@ -290,8 +290,11 @@ void socfpga_get_sys_mgr_addr(void)
 
 	ofnode node = ofnode_get_aliases_node("sysmgr");
 
+	if (!ofnode_valid(node))
+		node = ofnode_by_compatible(ofnode_null(), "altr,sys-mgr");
+
 	if (!ofnode_valid(node)) {
-		printf("'sysmgr' alias not found in device tree\n");
+		printf("sysmgr device tree node not found\n");
 		hang();
 	}
 
@@ -299,9 +302,9 @@ void socfpga_get_sys_mgr_addr(void)
 	if (ret) {
 		printf("Altera system manager init failed: %d\n", ret);
 		hang();
-	} else {
-		socfpga_sysmgr_base = (phys_addr_t)dev_read_addr(dev);
 	}
+
+	socfpga_sysmgr_base = (phys_addr_t)dev_read_addr(dev);
 }
 
 phys_addr_t socfpga_get_rstmgr_addr(void)


### PR DESCRIPTION
Stratix10 already probes altr_sysmgr through socfpga_get_sys_mgr_addr() (alias + BOARD_EARLY_INIT_F). However, some device trees provide the sysmgr node but omit the "sysmgr" alias, which will cause the DM path hung or leave socfpga_sysmgr_base unset and causes an abort in cm_get_qspi_controller_clk_hz.

Fall back to ofnode_by_compatible("altr,sys-mgr") and probe the same UCLASS_NOP driver so Stratix10 stays on the DM path without restoring of_flat_tree lookup.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
