### PR TITLE
configs: socfpga: Add QSPI support for Cyclone 5

### DIFF
--- a/arch/arm/mach-socfpga/Kconfig
+++ b/arch/arm/mach-socfpga/Kconfig
@@ -22,6 +22,18 @@ config SOCFPGA_SECURE_VAB_AUTH_ALLOW_NON_FIT_IMAGE
 	bool "Allow non-FIT VAB signed images"
 	depends on SOCFPGA_SECURE_VAB_AUTH
 
+config SOCFPGA_DISTRO_BOOT_QSPI
+	bool "Append QSPI to distro boot targets (boot_targets)"
+	depends on CMD_SF
+	default y if TARGET_SOCFPGA_CYCLONE5_SOCDK
+	help
+	  When enabled, socfpga_common.h adds QSPI to the distro boot
+	  device list and defines bootcmd_qspi (run qspiload; run
+	  qspiboot). The board header must supply qspiload and qspiboot
+	  in the default environment (for example via
+	  SOCFPGA_BOOT_SETTINGS). Disable on boards that enable CMD_SF
+	  for a small SPI flash or a layout incompatible with that flow.
+
 config SPL_SIZE_LIMIT
 	default 0x10000 if ARCH_SOCFPGA_GEN5
 

--- a/include/configs/socfpga_common.h
+++ b/include/configs/socfpga_common.h
@@ -137,10 +137,27 @@
 #define BOOT_TARGET_DEVICES_MMC(func)
 #endif
 
+#if IS_ENABLED(CONFIG_CMD_SF) && IS_ENABLED(CONFIG_SOCFPGA_DISTRO_BOOT_QSPI)
+#define BOOT_TARGET_DEVICES_QSPI(func) func(QSPI, qspi, na)
+#else
+#define BOOT_TARGET_DEVICES_QSPI(func)
+#endif
+
+#define BOOTENV_DEV_QSPI(devtypeu, devtypel, instance) \
+	"bootcmd_qspi=run qspiload; run qspiboot\0"
+
+#define BOOTENV_DEV_NAME_QSPI(devtypeu, devtypel, instance) \
+	"qspi "
+
 #define BOOT_TARGET_DEVICES(func) \
 	BOOT_TARGET_DEVICES_MMC(func) \
+	BOOT_TARGET_DEVICES_QSPI(func) \
 	BOOT_TARGET_DEVICES_PXE(func) \
 	BOOT_TARGET_DEVICES_DHCP(func)
+
+#ifndef SOCFPGA_BOOT_SETTINGS
+#define SOCFPGA_BOOT_SETTINGS
+#endif
 
 #include <config_distro_bootcmd.h>
 
@@ -154,6 +171,7 @@
 	"pxefile_addr_r=0x02200000\0" \
 	"ramdisk_addr_r=0x02300000\0" \
 	"socfpga_legacy_reset_compat=1\0" \
+	SOCFPGA_BOOT_SETTINGS \
 	BOOTENV
 
 #endif

--- a/include/configs/socfpga_cyclone5_socdk.h
+++ b/include/configs/socfpga_cyclone5_socdk.h
@@ -10,6 +10,24 @@
 /* Memory configurations */
 #define PHYS_SDRAM_1_SIZE		0x40000000	/* 1GiB on SoCDK */
 
+/* QSPI boot */
+#define FDT_SIZE		__stringify(0x00010000)
+#define KERNEL_SIZE		__stringify(0x005d0000)
+#define QSPI_FDT_ADDR		__stringify(0x00220000)
+#define QSPI_KERNEL_ADDR	__stringify(0x00230000)
+
+#define SOCFPGA_BOOT_SETTINGS \
+	"fdt_size=" FDT_SIZE "\0" \
+	"kernel_size=" KERNEL_SIZE "\0" \
+	"qspi_fdt_addr=" QSPI_FDT_ADDR "\0" \
+	"qspi_kernel_addr=" QSPI_KERNEL_ADDR "\0" \
+	"qspiboot=setenv bootargs earlycon " \
+		"root=/dev/mtdblock1 rw rootfstype=jffs2; " \
+		"bootz ${kernel_addr_r} - ${fdt_addr_r}\0" \
+	"qspiload=sf probe; " \
+		"sf read ${kernel_addr_r} ${qspi_kernel_addr} ${kernel_size}; " \
+		"sf read ${fdt_addr_r} ${qspi_fdt_addr} ${fdt_size}\0"
+
 /* The rest of the configuration is shared */
 #include <configs/socfpga_common.h>
 


### PR DESCRIPTION
Not intended to check in, just want to run pipeline test.

---

Add QSPI boot support to boot target devices list. Platform can provide their own boot settings through SOCFPGA_BOOT_SETTINGS macro if needed.

Add SOCFPGA_BOOT_SETTINGS for Cyclone 5.

Guard QSPI boot-target integration with a new Kconfig option, SOCFPGA_DISTRO_BOOT_QSPI, so that only boards which actually define qspiload/qspiboot get "qspi" appended to boot_targets. Without this, any SoCFPGA board enabling CONFIG_CMD_SF (e.g. Arria V, DE10, SoCKit) for an unrelated SPI flash use-case would also pick up bootcmd_qspi and could fail during distro autoboot

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
