### PR TITLE
Makefile: drop GNU Make < 4.0 compatibility code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ NAME =
 # Comments in this file are targeted only to the developer, do not
 # expect to learn how to build the kernel reading this file.
 
+ifeq ($(filter output-sync,$(.FEATURES)),)
+$(error GNU Make >= 4.0 is required. Your Make version is $(MAKE_VERSION))
+endif
+
 $(if $(filter __%, $(MAKECMDGOALS)), \
 	$(error targets prefixed with '__' are only for internal use))
 
@@ -93,14 +97,8 @@ endif
 
 # If the user is running make -s (silent mode), suppress echoing of
 # commands
-ifneq ($(filter 4.%,$(MAKE_VERSION)),)	# make-4
-ifneq ($(filter %s ,$(firstword x$(MAKEFLAGS))),)
+ifneq ($(findstring s,$(firstword -$(MAKEFLAGS))),)
   quiet=silent_
-endif
-else					# make-3.8x
-ifneq ($(filter s% -s%,$(MAKEFLAGS)),)
-  quiet=silent_
-endif
 endif
 
 export quiet Q KBUILD_VERBOSE
@@ -164,14 +162,6 @@ ifneq ($(abs_srctree),$(abs_objtree))
 # --included-dir is added for backward compatibility, but you should not rely on
 # it. Please add $(srctree)/ prefix to include Makefiles in the source tree.
 MAKEFLAGS += --include-dir=$(abs_srctree)
-endif
-
-ifneq ($(filter 3.%,$(MAKE_VERSION)),)
-# 'MAKEFLAGS += -rR' does not immediately become effective for GNU Make 3.x
-# We need to invoke sub-make to avoid implicit rules in the top Makefile.
-need-sub-make := 1
-# Cancel implicit rules for this Makefile.
-$(this-makefile): ;
 endif
 
 export abs_srctree abs_objtree


### PR DESCRIPTION
NOTE: CI-only.

RHEL/CentOS 7, a popular distribution that installs GNU Make 3.82, reached EOM/EOL on June 30, 2024. While you may get extended support, it is a good time to raise the minimum GNU Make version.

The new requirement, GNU Make 4.0, was released in October, 2013.

Raise the enforced minimum GNU Make version to 4.0 and drop the now-unreachable compatibility code for older versions:

- Add an explicit "GNU Make >= 4.0 is required" version-check gate.
- Simplify the "make -s" (silent mode) detection to a single unconditional check instead of branching on make-4 vs make-3.8x.
- Drop the GNU Make 3.x sub-make workaround, which is now dead code.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
